### PR TITLE
Extract "data" from inputArgs on mint/transfer calls

### DIFF
--- a/src/event-stream/event-stream.interfaces.ts
+++ b/src/event-stream/event-stream.interfaces.ts
@@ -34,6 +34,8 @@ export interface Event {
   transactionIndex: string;
   transactionHash: string;
   data: any;
+  inputMethod?: string;
+  inputArgs?: Record<string, any>;
 }
 
 export class EventStreamReplyHeaders {

--- a/src/event-stream/event-stream.service.ts
+++ b/src/event-stream/event-stream.service.ts
@@ -137,6 +137,7 @@ export class EventStreamService {
       type: 'websocket',
       websocket: { topic },
       blockedReryDelaySec: 30, // intentional due to spelling error in ethconnect
+      inputs: true,
     };
 
     const { data: existingStreams } = await this.http

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -46,6 +46,11 @@ export interface TransferSingleEvent extends Event {
   };
 }
 
+export interface PackedTokenData {
+  trackingId?: string;
+  data?: any;
+}
+
 // REST API requests and responses
 export class AsyncResponse {
   @ApiProperty()
@@ -60,7 +65,7 @@ export enum TokenType {
 const trackingIdDescription =
   'Optional ID provided by the client for correlating related events. This field ' +
   'will not be used or inspected by the server, but will be associated with the ' +
-  'token pool and returned alongside other pool info.';
+  'transaction and returned in any triggered events.';
 const requestIdDescription =
   'Optional ID to identify this request. Must be unique for every request. ' +
   'If none is provided, one will be assigned and returned in the 202 response.';
@@ -102,6 +107,10 @@ export class TokenMint {
   @IsInt()
   @Min(1)
   amount: number;
+
+  @ApiProperty({ description: trackingIdDescription })
+  @IsOptional()
+  trackingId?: string;
 
   @ApiProperty({ description: requestIdDescription })
   @IsOptional()
@@ -152,6 +161,10 @@ export class TokenTransfer {
   @IsInt()
   @Min(1)
   amount: number;
+
+  @ApiProperty({ description: trackingIdDescription })
+  @IsOptional()
+  trackingId?: string;
 
   @ApiProperty({ description: requestIdDescription })
   @IsOptional()
@@ -212,7 +225,10 @@ export class TokenMintEvent {
   operator: string;
 
   @ApiProperty()
-  data: string;
+  trackingId?: string;
+
+  @ApiProperty()
+  data?: string;
 
   @ApiProperty()
   transaction: BlockchainTransaction;
@@ -238,7 +254,10 @@ export class TokenTransferEvent {
   operator: string;
 
   @ApiProperty()
-  data: string;
+  trackingId?: string;
+
+  @ApiProperty()
+  data?: string;
 
   @ApiProperty()
   transaction: BlockchainTransaction;

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -215,6 +215,8 @@ class TokenListener implements EventListener {
 
   private transformTransferSingleEvent(event: TransferSingleEvent): WebSocketMessage | undefined {
     const { data } = event;
+    const inputData = event.inputArgs?.data;
+
     if (data.from === ZERO_ADDRESS && data.to === ZERO_ADDRESS) {
       // should not happen
       return undefined;
@@ -229,6 +231,7 @@ class TokenListener implements EventListener {
           to: data.to,
           amount: data.value,
           operator: data.operator,
+          data: inputData === undefined ? undefined : decodeHex(inputData),
           transaction: {
             blockNumber: event.blockNumber,
             transactionIndex: event.transactionIndex,
@@ -251,6 +254,7 @@ class TokenListener implements EventListener {
           to: data.to,
           amount: data.value,
           operator: data.operator,
+          data: inputData === undefined ? undefined : decodeHex(inputData),
           transaction: {
             blockNumber: event.blockNumber,
             transactionIndex: event.transactionIndex,

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -185,6 +185,8 @@ describe('AppController (e2e)', () => {
       poolId: 'F1',
       to: '1',
       amount: 2,
+      trackingId: 'abc',
+      data: 'test',
     };
     const response: EthConnectAsyncResponse = {
       id: '1',
@@ -202,7 +204,7 @@ describe('AppController (e2e)', () => {
         type_id: '340282366920938463463374607431768211456',
         to: ['1'],
         amounts: [2],
-        data: [0],
+        data: '0x7b22747261636b696e674964223a22616263222c2264617461223a2274657374227d',
       },
       OPTIONS,
     );
@@ -229,7 +231,7 @@ describe('AppController (e2e)', () => {
       {
         type_id: '57896044618658097711785492504343953926975274699741220483192166611388333031424',
         to: ['1', '1'],
-        data: [0],
+        data: '0x7b7d',
       },
       OPTIONS,
     );
@@ -289,7 +291,7 @@ describe('AppController (e2e)', () => {
         from: '1',
         to: '2',
         amount: 2,
-        data: [0],
+        data: '0x7b7d',
       },
       OPTIONS,
     );
@@ -363,7 +365,7 @@ describe('AppController (e2e)', () => {
             },
             inputMethod: 'mintFungible',
             inputArgs: {
-              data: '0x68656c6c6f',
+              data: '0x7b22747261636b696e674964223a22616263222c2264617461223a2274657374227d',
             },
           },
         ]);
@@ -379,7 +381,8 @@ describe('AppController (e2e)', () => {
             to: 'A',
             amount: 5,
             operator: 'A',
-            data: 'hello',
+            trackingId: 'abc',
+            data: 'test',
             transaction: {
               blockNumber: '1',
               transactionIndex: '0x0',

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -361,6 +361,10 @@ describe('AppController (e2e)', () => {
                 transactionHash: '0x123',
               },
             },
+            inputMethod: 'mintFungible',
+            inputArgs: {
+              data: '0x68656c6c6f',
+            },
           },
         ]);
       })
@@ -375,6 +379,7 @@ describe('AppController (e2e)', () => {
             to: 'A',
             amount: 5,
             operator: 'A',
+            data: 'hello',
             transaction: {
               blockNumber: '1',
               transactionIndex: '0x0',


### PR DESCRIPTION
Depends on https://github.com/hyperledger-labs/firefly-ethconnect/pull/147

Adds support for retrieving the `data` field from mint/transfer events via the new `inputArgs` item returned from ethconnect.

Also splits out a `trackingId` (which is packed alongside the other pass-thru data) for mint/transfer.