### PR TITLE
Replace arbitrary "data" param on /pool with individual fields

### DIFF
--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -57,18 +57,36 @@ export enum TokenType {
   NONFUNGIBLE = 'nonfungible',
 }
 
+const trackingIdDescription =
+  'Optional ID provided by the client for correlating related events. This field ' +
+  'will not be used or inspected by the server, but will be associated with the ' +
+  'token pool and returned alongside other pool info.';
+const requestIdDescription =
+  'Optional ID to identify this request. Must be unique for every request. ' +
+  'If none is provided, one will be assigned and returned in the 202 response.';
+const poolConfigDescription =
+  'Optional configuration info for the token pool. Reserved for future use.';
+
 export class TokenPool {
   @ApiProperty({ enum: TokenType })
   @IsDefined()
   type: TokenType;
 
-  @ApiProperty()
+  @ApiProperty({ description: trackingIdDescription })
+  @IsOptional()
+  trackingId?: string;
+
+  @ApiProperty({ description: requestIdDescription })
   @IsOptional()
   requestId?: string;
 
+  @ApiProperty({ description: poolConfigDescription })
+  @IsOptional()
+  config?: any;
+
   @ApiProperty()
   @IsOptional()
-  data?: string;
+  data?: string; // TODO: remove
 }
 
 export class TokenMint {
@@ -85,7 +103,7 @@ export class TokenMint {
   @Min(1)
   amount: number;
 
-  @ApiProperty()
+  @ApiProperty({ description: requestIdDescription })
   @IsOptional()
   requestId?: string;
 
@@ -135,7 +153,7 @@ export class TokenTransfer {
   @Min(1)
   amount: number;
 
-  @ApiProperty()
+  @ApiProperty({ description: requestIdDescription })
   @IsOptional()
   requestId?: string;
 
@@ -168,7 +186,10 @@ export class TokenPoolEvent {
   operator: string;
 
   @ApiProperty()
-  data: string;
+  trackingId?: string;
+
+  @ApiProperty()
+  data?: string; // TODO: remove
 
   @ApiProperty()
   transaction: BlockchainTransaction;

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { HttpService, Injectable, Logger } from '@nestjs/common';
+import { HttpService, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { WebSocketMessage } from '../websocket-events/websocket-events.base';
 import { EventListener } from '../eventstream-proxy/eventstream-proxy.interfaces';
 import { EventStreamProxyGateway } from '../eventstream-proxy/eventstream-proxy.gateway';
@@ -81,8 +81,15 @@ export class TokensService {
 
   async getReceipt(id: string): Promise<EventStreamReply> {
     const response = await this.http
-      .get<EventStreamReply>(`${this.baseUrl}/reply/${id}`)
+      .get<EventStreamReply>(`${this.baseUrl}/reply/${id}`, {
+          validateStatus: status => {
+            return status < 300 || status === 404;
+          },
+      })
       .toPromise();
+    if (response.status === 404) {
+      throw new NotFoundException()
+    }
     return response.data;
   }
 

--- a/src/tokens/tokens.util.spec.ts
+++ b/src/tokens/tokens.util.spec.ts
@@ -14,12 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {
-  decodeHex,
-  encodeHex,
-  packTokenId,
-  unpackTokenId,
-} from './tokens.util';
+import { decodeHex, encodeHex, packTokenId, unpackTokenId } from './tokens.util';
 
 describe('Util', () => {
   it('encodeHex', () => {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -125,30 +125,31 @@ describe('AppController (e2e)', () => {
   it('Create fungible pool', async () => {
     const request: TokenPool = {
       type: TokenType.FUNGIBLE,
+      requestId: 'op1',
+      trackingId: 'tx1',
       data: 'test',
-      requestId: '12345',
     };
     const response: EthConnectAsyncResponse = {
-      id: '12345',
+      id: 'op1',
       sent: true,
     };
 
     http.post = jest.fn(() => new FakeObservable(response));
 
-    await server.post('/pool').send(request).expect(202).expect({ id: '12345' });
+    await server.post('/pool').send(request).expect(202).expect({ id: 'op1' });
 
     expect(http.post).toHaveBeenCalledTimes(1);
     expect(http.post).toHaveBeenCalledWith(
       `${INSTANCE_URL}/create`,
       {
-        data: '0x74657374',
+        data: '0x7b22747261636b696e674964223a22747831222c2264617461223a2274657374227d',
         is_fungible: true,
       },
       {
         ...OPTIONS,
         params: {
           ...OPTIONS.params,
-          'fly-id': '12345',
+          'fly-id': 'op1',
         },
       },
     );
@@ -172,7 +173,7 @@ describe('AppController (e2e)', () => {
     expect(http.post).toHaveBeenCalledWith(
       `${INSTANCE_URL}/create`,
       {
-        data: '0x74657374',
+        data: '0x7b2264617461223a2274657374227d',
         is_fungible: false,
       },
       OPTIONS,
@@ -309,7 +310,7 @@ describe('AppController (e2e)', () => {
             data: {
               operator: 'bob',
               type_id: '340282366920938463463374607431768211456',
-              data: '0x74657374',
+              data: '0x7b22747261636b696e674964223a22747831222c2264617461223a2274657374227d',
             },
           },
         ]);
@@ -321,6 +322,7 @@ describe('AppController (e2e)', () => {
           event: 'token-pool',
           data: <TokenPoolEvent>{
             data: 'test',
+            trackingId: 'tx1',
             poolId: 'F1',
             type: 'fungible',
             operator: 'bob',


### PR DESCRIPTION
This has gone back and forth a few times, but it does seem like there's a
specific need for a "trackingId" that can be used to correlate the request with
the created pool, and that this is the only piece of extra data that needs to
be written to the chain.

Also adds a "config" parameter to the API - not used currently, but this
gives some future-proofing so it will be accepted and ignored by this version
of the connector if it is needed in the future.
