### PR TITLE
Correct license in package.json to Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "author": "",
   "private": true,
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",


### PR DESCRIPTION
This should match the actual governing license from the LICENSE file.