### PR TITLE
Rsjx version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,23 @@
         "magic-string": "0.25.7",
         "rxjs": "6.6.7",
         "source-map": "0.7.3"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "@angular-devkit/schematics": {
@@ -27,6 +44,23 @@
         "@angular-devkit/core": "12.2.7",
         "ora": "5.4.1",
         "rxjs": "6.6.7"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "@angular-devkit/schematics-cli": {
@@ -1296,6 +1330,17 @@
             "magic-string": "0.25.7",
             "rxjs": "6.6.7",
             "source-map": "0.7.3"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.6.7",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+              "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+              "dev": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
           }
         },
         "@angular-devkit/schematics": {
@@ -1307,6 +1352,17 @@
             "@angular-devkit/core": "12.0.5",
             "ora": "5.4.0",
             "rxjs": "6.6.7"
+          },
+          "dependencies": {
+            "rxjs": {
+              "version": "6.6.7",
+              "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+              "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+              "dev": true,
+              "requires": {
+                "tslib": "^1.9.0"
+              }
+            }
           }
         },
         "ajv": {
@@ -1346,6 +1402,12 @@
             "strip-ansi": "^6.0.0",
             "wcwidth": "^1.0.1"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -4363,6 +4425,23 @@
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "internal-slot": {
@@ -7117,17 +7196,17 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "~2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "supertest": "^6.0.0",
     "superwstest": "^1.4.0",
     "ts-jest": "^27.0.5",
-    "ts-loader": "^8.0.8",
-    "ts-node": "^9.0.0",
-    "tsconfig-paths": "^3.9.0",
-    "typescript": "^4.0.5"
+    "ts-loader": "^9.2.6",
+    "ts-node": "^10.2.1",
+    "tsconfig-paths": "^3.11.0",
+    "typescript": "^4.4.3"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "nanoid": "^3.1.23",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
-    "rxjs": "^6.6.3",
+    "rxjs": "^7.4.0",
     "swagger-ui-express": "^4.1.6",
     "uuid": "^8.3.2",
     "ws": "^8.0.0"

--- a/src/event-stream/event-stream.service.ts
+++ b/src/event-stream/event-stream.service.ts
@@ -15,12 +15,14 @@
 // limitations under the License.
 
 import { HttpService, Injectable, Logger } from '@nestjs/common';
+import { AxiosResponse } from 'axios';
+import { lastValueFrom } from 'rxjs';
 import * as WebSocket from 'ws';
 import {
   Event,
   EventStream,
   EventStreamReply,
-  EventStreamSubscription,
+  EventStreamSubscription
 } from './event-stream.interfaces';
 
 const RECONNECT_TIME = 5000;
@@ -142,22 +144,19 @@ export class EventStreamService {
       inputs: true,
     };
 
-    const { data: existingStreams } = await this.http
-      .get<EventStream[]>(`${baseUrl}/eventstreams`)
-      .toPromise();
-    const stream = existingStreams.find(s => s.name === streamDetails.name);
+    const existingStreamRes: AxiosResponse<EventStream[]> = await lastValueFrom(this.http
+      .get<EventStream[]>(`${baseUrl}/eventstreams`));
+    const stream = existingStreamRes.data.find(s => s.name === streamDetails.name);
     if (stream) {
-      const { data: patchedStream } = await this.http
-        .patch<EventStream>(`${baseUrl}/eventstreams/${stream.id}`, streamDetails)
-        .toPromise();
+      const patchedStreamRes: AxiosResponse<EventStream> = await lastValueFrom(this.http
+        .patch<EventStream>(`${baseUrl}/eventstreams/${stream.id}`, streamDetails));
       this.logger.log(`Event stream for ${topic}: ${stream.id}`);
-      return patchedStream;
+      return patchedStreamRes.data;
     }
-    const { data: newStream } = await this.http
-      .post<EventStream>(`${baseUrl}/eventstreams`, streamDetails)
-      .toPromise();
-    this.logger.log(`Event stream for ${topic}: ${newStream.id}`);
-    return newStream;
+    const newStreamRes: AxiosResponse<EventStream> = await lastValueFrom(this.http
+      .post<EventStream>(`${baseUrl}/eventstreams`, streamDetails));
+    this.logger.log(`Event stream for ${topic}: ${newStreamRes.data.id}`);
+    return newStreamRes.data;
   }
 
   private async createSubscription(
@@ -165,14 +164,13 @@ export class EventStreamService {
     event: string,
     streamId: string,
   ): Promise<EventStreamSubscription> {
-    const response = await this.http
+    const response: AxiosResponse<EventStreamSubscription> = await lastValueFrom(this.http
       .post<EventStreamSubscription>(`${instanceUrl}/${event}`, {
         name: event,
         description: event,
         stream: streamId,
         fromBlock: '0', // subscribe from the start of the chain
-      })
-      .toPromise();
+      }));
     this.logger.log(`Created subscription ${event}: ${response.data.id}`);
     return response.data;
   }
@@ -183,12 +181,11 @@ export class EventStreamService {
     streamId: string,
     subscriptions: string[],
   ): Promise<EventStreamSubscription[]> {
-    const { data: existing } = await this.http
-      .get<EventStreamSubscription[]>(`${baseUrl}/subscriptions`)
-      .toPromise();
+    const existingRes: AxiosResponse<EventStreamSubscription[]> = await lastValueFrom(this.http
+      .get<EventStreamSubscription[]>(`${baseUrl}/subscriptions`));
     const results: EventStreamSubscription[] = [];
     for (const eventName of subscriptions) {
-      const sub = existing.find(s => s.name === eventName && s.stream === streamId);
+      const sub = existingRes.data.find(s => s.name === eventName && s.stream === streamId);
       if (sub) {
         this.logger.log(`Subscription for ${eventName}: ${sub.id}`);
         results.push(sub);

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -15,11 +15,12 @@
 // limitations under the License.
 
 import { HttpService, Injectable, Logger, NotFoundException } from '@nestjs/common';
-import { WebSocketMessage } from '../websocket-events/websocket-events.base';
-import { EventListener } from '../eventstream-proxy/eventstream-proxy.interfaces';
-import { EventStreamProxyGateway } from '../eventstream-proxy/eventstream-proxy.gateway';
+import { AxiosResponse } from 'axios';
+import { lastValueFrom } from 'rxjs';
 import { Event, EventStreamReply } from '../event-stream/event-stream.interfaces';
-import { isFungible, packTokenId, unpackTokenId, encodeHex, decodeHex } from './tokens.util';
+import { EventStreamProxyGateway } from '../eventstream-proxy/eventstream-proxy.gateway';
+import { EventListener } from '../eventstream-proxy/eventstream-proxy.interfaces';
+import { WebSocketMessage } from '../websocket-events/websocket-events.base';
 import {
   AsyncResponse,
   EthConnectAsyncResponse,
@@ -37,8 +38,9 @@ import {
   TokenTransfer,
   TokenTransferEvent,
   TokenType,
-  TransferSingleEvent,
+  TransferSingleEvent
 } from './tokens.interfaces';
+import { decodeHex, encodeHex, isFungible, packTokenId, unpackTokenId } from './tokens.util';
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 
@@ -77,13 +79,12 @@ export class TokensService {
   }
 
   async getReceipt(id: string): Promise<EventStreamReply> {
-    const response = await this.http
+    const response: AxiosResponse<EventStreamReply> = await lastValueFrom(this.http
       .get<EventStreamReply>(`${this.baseUrl}/reply/${id}`, {
         validateStatus: status => {
           return status < 300 || status === 404;
         },
-      })
-      .toPromise();
+      }));
     if (response.status === 404) {
       throw new NotFoundException();
     }
@@ -95,7 +96,7 @@ export class TokensService {
       trackingId: dto.trackingId,
       data: dto.data, // TODO: remove
     };
-    const response = await this.http
+    const response = await lastValueFrom(this.http
       .post<EthConnectAsyncResponse>(
         `${this.instanceUrl}/create`,
         {
@@ -103,8 +104,7 @@ export class TokensService {
           data: encodeHex(JSON.stringify(dataToPack)),
         },
         this.postOptions(dto.requestId),
-      )
-      .toPromise();
+      ));
     return { id: response.data.id };
   }
 
@@ -115,7 +115,7 @@ export class TokensService {
       data: dto.data,
     };
     if (isFungible(dto.poolId)) {
-      const response = await this.http
+      const response = await lastValueFrom(this.http
         .post<EthConnectAsyncResponse>(
           `${this.instanceUrl}/mintFungible`,
           {
@@ -125,8 +125,7 @@ export class TokensService {
             data: encodeHex(JSON.stringify(dataToPack)),
           },
           this.postOptions(dto.requestId),
-        )
-        .toPromise();
+        ));
       return { id: response.data.id };
     } else {
       // In the case of a non-fungible token:
@@ -138,7 +137,7 @@ export class TokensService {
         to.push(dto.to);
       }
 
-      const response = await this.http
+      const response = await lastValueFrom(this.http
         .post<EthConnectAsyncResponse>(
           `${this.instanceUrl}/mintNonFungible`,
           {
@@ -147,8 +146,7 @@ export class TokensService {
             data: encodeHex(JSON.stringify(dataToPack)),
           },
           this.postOptions(dto.requestId),
-        )
-        .toPromise();
+        ));
       return { id: response.data.id };
     }
   }
@@ -158,7 +156,7 @@ export class TokensService {
       trackingId: dto.trackingId,
       data: dto.data,
     };
-    const response = await this.http
+    const response = await lastValueFrom(this.http
       .post<EthConnectAsyncResponse>(
         `${this.instanceUrl}/safeTransferFrom`,
         {
@@ -169,8 +167,7 @@ export class TokensService {
           data: encodeHex(JSON.stringify(dataToPack)),
         },
         this.postOptions(dto.requestId),
-      )
-      .toPromise();
+      ));
     return { id: response.data.id };
   }
 
@@ -179,7 +176,7 @@ export class TokensService {
       trackingId: dto.trackingId,
       data: dto.data,
     };
-    const response = await this.http
+    const response = await lastValueFrom(this.http
       .post<EthConnectAsyncResponse>(
         `${this.instanceUrl}/burn`,
         {
@@ -189,20 +186,18 @@ export class TokensService {
           data: encodeHex(JSON.stringify(dataToPack)),
         },
         this.postOptions(dto.requestId),
-      )
-      .toPromise();
+      ));
     return { id: response.data.id };
   }
 
   async balance(dto: TokenBalanceQuery): Promise<TokenBalance> {
-    const response = await this.http
+    const response = await lastValueFrom(this.http
       .get<EthConnectReturn>(`${this.instanceUrl}/balanceOf`, {
         params: {
           account: dto.account,
           id: packTokenId(dto.poolId, dto.tokenIndex),
         },
-      })
-      .toPromise();
+      }));
     return { balance: response.data.output };
   }
 }


### PR DESCRIPTION
Not sure why we didn't see this in the Github actions builds, but after building API calls are failing due to the below stack.
See https://github.com/hyperledger/firefly/pull/215#issuecomment-940150647

This is due to a move in rsjx 7 that deprecated `toPromise`, and you should explicitly now use `lastValueOf`.
However, in my VSCode I did find the automatic type casting was a faff, and I had to make some more tweaks.

```
�[34;1mtokens_0_1        |�[0m �[32m[Nest] 17  - �[39m10/11/2021, 3:52:08 PM �[32m    LOG�[39m �[38;5;3m[RequestLogging] �[39m�[32mPOST /api/v1/init�[39m
�[34;1mtokens_0_1        |�[0m �[31m[Nest] 17  - �[39m10/11/2021, 3:52:08 PM �[31m  ERROR�[39m �[38;5;3m[ExceptionsHandler] �[39m�[31mrxjs_1.lastValueFrom is not a function�[39m
�[34;1mtokens_0_1        |�[0m TypeError: rxjs_1.lastValueFrom is not a function
�[34;1mtokens_0_1        |�[0m     at RouterResponseController.transformToResult (/root/node_modules/@nestjs/core/router/router-response-controller.js:32:27)
�[34;1mtokens_0_1        |�[0m     at /root/node_modules/@nestjs/core/router/router-execution-context.js:173:52
�[34;1mtokens_0_1        |�[0m     at /root/node_modules/@nestjs/core/router/router-execution-context.js:47:19
�[34;1mtokens_0_1        |�[0m     at processTicksAndRejections (internal/process/task_queues.js:95:5)
�[34;1mtokens_0_1        |�[0m     at async /root/node_modules/@nestjs/core/router/router-proxy.js:9:17
```