### PR TITLE
Do not use tokenIndex for fungible pools

### DIFF
--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -119,8 +119,8 @@ export class TokenTransfer {
   poolId: string;
 
   @ApiProperty()
-  @IsNotEmpty()
-  tokenIndex: string;
+  @IsOptional()
+  tokenIndex?: string;
 
   @ApiProperty()
   @IsNotEmpty()
@@ -187,7 +187,7 @@ export class TokenPoolEvent extends tokenEventBase {
 
 export class TokenTransferEvent extends tokenEventBase {
   @ApiProperty()
-  tokenIndex: string;
+  tokenIndex?: string;
 
   @ApiProperty()
   from: string;

--- a/src/tokens/tokens.util.spec.ts
+++ b/src/tokens/tokens.util.spec.ts
@@ -40,7 +40,6 @@ describe('Util', () => {
     expect(unpackTokenId('340282366920938463463374607431768211456')).toEqual({
       isFungible: true,
       poolId: 'F1',
-      tokenIndex: '0',
     });
     expect(
       unpackTokenId(

--- a/src/tokens/tokens.util.ts
+++ b/src/tokens/tokens.util.ts
@@ -40,6 +40,6 @@ export function unpackTokenId(id: string) {
   return {
     isFungible: isFungible,
     poolId: (isFungible ? 'F' : 'N') + (BigInt.asUintN(255, val) >> BigInt(128)),
-    tokenIndex: BigInt.asUintN(128, val).toString(),
+    tokenIndex: isFungible ? undefined : BigInt.asUintN(128, val).toString(),
   };
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -282,7 +282,6 @@ describe('AppController (e2e)', () => {
   it('Transfer token', async () => {
     const request: TokenTransfer = {
       poolId: 'F1',
-      tokenIndex: '0',
       from: '1',
       to: '2',
       amount: '2',
@@ -419,7 +418,6 @@ describe('AppController (e2e)', () => {
           event: 'token-mint',
           data: <TokenMintEvent>{
             poolId: 'F1',
-            tokenIndex: '0',
             to: 'A',
             amount: '5',
             operator: 'A',
@@ -449,7 +447,7 @@ describe('AppController (e2e)', () => {
             transactionIndex: '0x0',
             transactionHash: '0x123',
             data: {
-              id: '340282366920938463463374607431768211456',
+              id: '57896044618658097711785492504343953926975274699741220483192166611388333031425',
               from: 'A',
               to: ZERO_ADDRESS,
               operator: 'A',
@@ -473,8 +471,8 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-burn',
           data: <TokenBurnEvent>{
-            poolId: 'F1',
-            tokenIndex: '0',
+            poolId: 'N1',
+            tokenIndex: '1',
             from: 'A',
             amount: '1',
             operator: 'A',


### PR DESCRIPTION
This is irrelevant (always 0), so do not require it to be passed or
pass it back in events.