### PR TITLE
Remove auto-migration logic for subscriptions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import { TokensService } from './tokens/tokens.service';
 import { EventStreamProxyGateway } from './eventstream-proxy/eventstream-proxy.gateway';
 import { EventStreamReply } from './event-stream/event-stream.interfaces';
 import {
+  TokenApprovalEvent,
   TokenBurnEvent,
   TokenMintEvent,
   TokenPoolEvent,
@@ -61,6 +62,7 @@ async function bootstrap() {
       TokenMintEvent,
       TokenBurnEvent,
       TokenTransferEvent,
+      TokenApprovalEvent,
     ],
   });
   const config = app.get(ConfigService);

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,7 +84,7 @@ async function bootstrap() {
     .configure(ethConnectUrl, instancePath, topic, shortPrefix, username, password);
 
   try {
-    await app.get(TokensService).migrate();
+    await app.get(TokensService).migrationCheck();
   } catch (err) {
     // do nothing
   }

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -239,9 +239,6 @@ class tokenEventBase {
   poolId: string;
 
   @ApiProperty()
-  type: TokenType;
-
-  @ApiProperty()
   signer: string;
 
   @ApiProperty()
@@ -264,6 +261,9 @@ class tokenEventBase {
 }
 
 export class TokenPoolEvent extends tokenEventBase {
+  @ApiProperty()
+  type: TokenType;
+
   @ApiProperty()
   standard: string;
 }
@@ -290,3 +290,11 @@ export class TokenTransferEvent extends tokenEventBase {
 
 export class TokenMintEvent extends OmitType(TokenTransferEvent, ['from']) {}
 export class TokenBurnEvent extends OmitType(TokenTransferEvent, ['to']) {}
+
+export class TokenApprovalEvent extends tokenEventBase {
+  @ApiProperty()
+  operator: string;
+
+  @ApiProperty()
+  approved: boolean;
+}

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -77,12 +77,25 @@ describe('TokensService', () => {
       expect(await service.migrationCheck()).toBe(false);
     });
 
-    it('should migrate if event subscriptions are missing', async () => {
+    it('should migrate if any event subscriptions are missing', async () => {
       service.topic = 'tokens';
       service.instancePath = '0x123';
       eventStream.getStreams.mockReturnValueOnce([{ name: 'tokens:0x123' }]);
       eventStream.getSubscriptions.mockReturnValueOnce([{ name: 'tokens:0x123:p1:TokenCreate' }]);
       expect(await service.migrationCheck()).toBe(true);
+    });
+
+    it('should not migrate if all event subscriptions exist', async () => {
+      service.topic = 'tokens';
+      service.instancePath = '0x123';
+      eventStream.getStreams.mockReturnValueOnce([{ name: 'tokens:0x123' }]);
+      eventStream.getSubscriptions.mockReturnValueOnce([
+        { name: 'tokens:0x123:p1:TokenCreate' },
+        { name: 'tokens:0x123:p1:TransferSingle' },
+        { name: 'tokens:0x123:p1:TransferBatch' },
+        { name: 'tokens:0x123:p1:ApprovalForAll' },
+      ]);
+      expect(await service.migrationCheck()).toBe(false);
     });
   });
 });

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -61,13 +61,28 @@ describe('TokensService', () => {
   });
 
   describe('Subscription migration', () => {
+    it('should not migrate if no subscriptions exists', async () => {
+      service.topic = 'tokens';
+      service.instancePath = '0x123';
+      eventStream.getStreams.mockReturnValueOnce([{ name: 'tokens:0x123' }]);
+      eventStream.getSubscriptions.mockReturnValueOnce([]);
+      expect(await service.migrationCheck()).toBe(false);
+    });
+
     it('should not migrate if correct base subscription exists', async () => {
       service.topic = 'tokens';
       service.instancePath = '0x123';
       eventStream.getStreams.mockReturnValueOnce([{ name: 'tokens:0x123' }]);
       eventStream.getSubscriptions.mockReturnValueOnce([{ name: 'tokens:0x123:base:TokenCreate' }]);
+      expect(await service.migrationCheck()).toBe(false);
+    });
 
-      await service.migrate();
+    it('should migrate if event subscriptions are missing', async () => {
+      service.topic = 'tokens';
+      service.instancePath = '0x123';
+      eventStream.getStreams.mockReturnValueOnce([{ name: 'tokens:0x123' }]);
+      eventStream.getSubscriptions.mockReturnValueOnce([{ name: 'tokens:0x123:p1:TokenCreate' }]);
+      expect(await service.migrationCheck()).toBe(true);
     });
   });
 });


### PR DESCRIPTION
The ERC1155 connector currently attempts to detect when event subscriptions need to be deleted and recreated
(for instance, because new events are now supported and require new subscriptions). While this can be convenient,
it also has the potential to cause negative side effects if the new subscriptions fail to create.

Remove the auto-migration path and downgrade this situation to a warning log. This means it will require manual
intervention from a user if (in the future) we add features that require subscriptions to be recreated.