### PR TITLE
Clarify token fields around "id", "locator", and "subject"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ calls, and maps ethconnect events to outgoing websocket events.
 The following POST APIs are exposed under `/api/v1`:
 
 * `POST /createpool` - Create a new token pool (inputs: type, data)
-* `POST /activatepool` - Activate a token pool to begin receiving transfers (inputs: poolId)
-* `POST /mint` - Mint new tokens (inputs: poolId, to, amount, data)
-* `POST /burn` - Burn tokens (inputs: poolId, tokenIndex, from, amount, data)
-* `POST /transfer` - Transfer tokens (inputs: poolId, tokenIndex, from, to, amount, data)
+* `POST /activatepool` - Activate a token pool to begin receiving transfers (inputs: poolLocator)
+* `POST /mint` - Mint new tokens (inputs: poolLocator, to, amount, data)
+* `POST /burn` - Burn tokens (inputs: poolLocator, tokenIndex, from, amount, data)
+* `POST /transfer` - Transfer tokens (inputs: poolLocator, tokenIndex, from, to, amount, data)
 
 All requests may be optionally accompanied by a `requestId`, which must be unique for every
 request and will be returned in the "receipt" websocket event.
@@ -39,11 +39,11 @@ not require any acknowledgment).
 Successful POST operations will also result in a detailed event corresponding to the type of
 transaction that was performed. The events and corresponding data items are:
 
-* `token-pool` - Token pool created (outputs: poolId, signer, type, data)
-* `token-mint` - Tokens minted (outputs: id, poolId, tokenIndex, uri, signer, to, amount, data)
-* `token-burn` - Tokens burned (outputs: id, poolId, tokenIndex, uri, signer, from, amount, data)
-* `token-transfer` - Tokens transferred (outputs: id, poolId, tokenIndex, uri, signer, from, to, amount, data)
-* `token-approval` - Tokens approved (outputs: id, poolId, signer, operator, approved, data)
+* `token-pool` - Token pool created (outputs: poolLocator, signer, type, data)
+* `token-mint` - Tokens minted (outputs: subject, poolLocator, tokenIndex, uri, signer, to, amount, data)
+* `token-burn` - Tokens burned (outputs: subject, poolLocator, tokenIndex, uri, signer, from, amount, data)
+* `token-transfer` - Tokens transferred (outputs: subject, poolLocator, tokenIndex, uri, signer, from, to, amount, data)
+* `token-approval` - Tokens approved (outputs: subject, poolLocator, signer, operator, approved, data)
 
 If multiple websocket clients are connected, only one will receive these events.
 Each one of these _must_ be acknowledged by replying on the websocket with `{event: "ack", data: {id}}`.
@@ -52,7 +52,7 @@ Each one of these _must_ be acknowledged by replying on the websocket with `{eve
 
 The following GET APIs are exposed under `/api/v1`:
 
-* `GET /balance` - Get token balance (inputs: poolId, tokenIndex, account)
+* `GET /balance` - Get token balance (inputs: poolLocator, tokenIndex, account)
 * `GET /receipt/:id` - Get receipt for a previous request
 
 ## Running the service

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Successful POST operations will also result in a detailed event corresponding to
 transaction that was performed. The events and corresponding data items are:
 
 * `token-pool` - Token pool created (outputs: poolLocator, signer, type, data)
-* `token-mint` - Tokens minted (outputs: subject, poolLocator, tokenIndex, uri, signer, to, amount, data)
-* `token-burn` - Tokens burned (outputs: subject, poolLocator, tokenIndex, uri, signer, from, amount, data)
-* `token-transfer` - Tokens transferred (outputs: subject, poolLocator, tokenIndex, uri, signer, from, to, amount, data)
-* `token-approval` - Tokens approved (outputs: subject, poolLocator, signer, operator, approved, data)
+* `token-mint` - Tokens minted (outputs: id, poolLocator, tokenIndex, uri, signer, to, amount, data)
+* `token-burn` - Tokens burned (outputs: id, poolLocator, tokenIndex, uri, signer, from, amount, data)
+* `token-transfer` - Tokens transferred (outputs: id, poolLocator, tokenIndex, uri, signer, from, to, amount, data)
+* `token-approval` - Tokens approved (outputs: id, subject, poolLocator, signer, operator, approved, data)
 
 If multiple websocket clients are connected, only one will receive these events.
 Each one of these _must_ be acknowledged by replying on the websocket with `{event: "ack", data: {id}}`.

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -296,7 +296,7 @@ export class TokenPoolEvent extends tokenEventBase {
 
 export class TokenTransferEvent extends tokenEventBase {
   @ApiProperty()
-  id: string;
+  subject: string;
 
   @ApiProperty()
   tokenIndex?: string;
@@ -318,6 +318,9 @@ export class TokenMintEvent extends OmitType(TokenTransferEvent, ['from']) {}
 export class TokenBurnEvent extends OmitType(TokenTransferEvent, ['to']) {}
 
 export class TokenApprovalEvent extends tokenEventBase {
+  @ApiProperty()
+  subject: string;
+
   @ApiProperty()
   operator: string;
 

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -109,7 +109,7 @@ export class TokenPool {
 export class TokenApproval {
   @ApiProperty()
   @IsNotEmpty()
-  poolId: string;
+  poolLocator: string;
 
   @ApiProperty()
   @IsNotEmpty()
@@ -185,7 +185,7 @@ export class BlockchainEvent {
 export class TokenPoolActivate {
   @ApiProperty()
   @IsNotEmpty()
-  poolId: string;
+  poolLocator: string;
 
   @ApiProperty()
   @IsOptional()
@@ -203,7 +203,7 @@ export class TokenPoolActivate {
 export class TokenBalanceQuery {
   @ApiProperty()
   @IsNotEmpty()
-  poolId: string;
+  poolLocator: string;
 
   @ApiProperty()
   @IsNotEmpty()
@@ -222,7 +222,7 @@ export class TokenBalance {
 export class TokenTransfer {
   @ApiProperty()
   @IsNotEmpty()
-  poolId: string;
+  poolLocator: string;
 
   @ApiProperty()
   @IsOptional()
@@ -260,7 +260,7 @@ export class TokenBurn extends OmitType(TokenTransfer, ['to']) {}
 
 class tokenEventBase {
   @ApiProperty()
-  poolId: string;
+  poolLocator: string;
 
   @ApiProperty()
   signer: string;

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -298,7 +298,7 @@ export class TokenPoolEvent extends tokenEventBase {
 
 export class TokenTransferEvent extends tokenEventBase {
   @ApiProperty()
-  subject: string;
+  id: string;
 
   @ApiProperty()
   tokenIndex?: string;
@@ -320,6 +320,9 @@ export class TokenMintEvent extends OmitType(TokenTransferEvent, ['from']) {}
 export class TokenBurnEvent extends OmitType(TokenTransferEvent, ['to']) {}
 
 export class TokenApprovalEvent extends tokenEventBase {
+  @ApiProperty()
+  id: string;
+
   @ApiProperty()
   subject: string;
 

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -18,7 +18,15 @@ import { ApiProperty, OmitType } from '@nestjs/swagger';
 import { IsDefined, IsNotEmpty, IsOptional } from 'class-validator';
 import { Event } from '../event-stream/event-stream.interfaces';
 
+// Internal types
+
+export interface PoolLocator {
+  poolId: string;
+  blockNumber?: string;
+}
+
 // Ethconnect interfaces
+
 export interface EthConnectAsyncResponse {
   sent: boolean;
   id: string;
@@ -136,13 +144,11 @@ export class TokenApproval {
   config?: any;
 }
 
-export class BlockLocator {
+export class BlockchainInfo {
   @ApiProperty()
   @IsNotEmpty()
   blockNumber: string;
-}
 
-export class BlockchainInfo extends BlockLocator {
   @ApiProperty()
   transactionIndex: string;
 
@@ -190,10 +196,6 @@ export class TokenPoolActivate {
   @ApiProperty()
   @IsOptional()
   config?: any;
-
-  @ApiProperty()
-  @IsOptional()
-  locator?: BlockLocator;
 
   @ApiProperty({ description: requestIdDescription })
   @IsOptional()

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -519,7 +519,7 @@ class TokenListener implements EventListener {
         : blockchainId + '/' + eventIndex.toString(10).padStart(6, '0');
 
     const commonData = <TokenTransferEvent>{
-      id: transferId,
+      subject: transferId,
       poolId: unpackedId.poolId,
       tokenIndex: unpackedId.tokenIndex,
       uri: await this.getTokenUri(output.id),
@@ -605,7 +605,7 @@ class TokenListener implements EventListener {
     return {
       event: 'token-approval',
       data: <TokenApprovalEvent>{
-        id: `${output.account}:${output.operator}`,
+        subject: `${output.account}:${output.operator}`,
         poolId: unpackedSub.poolId,
         operator: output.operator,
         approved: output.approved,

--- a/src/tokens/tokens.util.spec.ts
+++ b/src/tokens/tokens.util.spec.ts
@@ -18,9 +18,11 @@ import {
   decodeHex,
   encodeHex,
   encodeHexIDForURI,
+  packPoolLocator,
   packStreamName,
   packSubscriptionName,
   packTokenId,
+  unpackPoolLocator,
   unpackSubscriptionName,
   unpackTokenId,
 } from './tokens.util';
@@ -55,7 +57,7 @@ describe('Util', () => {
   it('unpackTokenId', () => {
     expect(unpackTokenId('340282366920938463463374607431768211456')).toEqual({
       isFungible: true,
-      poolLocator: 'F1',
+      poolId: 'F1',
     });
     expect(
       unpackTokenId(
@@ -63,8 +65,22 @@ describe('Util', () => {
       ),
     ).toEqual({
       isFungible: false,
-      poolLocator: 'N1',
+      poolId: 'N1',
       tokenIndex: '1',
+    });
+  });
+
+  it('packPoolLocator', () => {
+    expect(packPoolLocator('N1', '5')).toEqual('id=N1&block=5');
+  });
+
+  it('unpackPoolLocator', () => {
+    expect(unpackPoolLocator('id=N1&block=5')).toEqual({
+      poolId: 'N1',
+      blockNumber: '5',
+    });
+    expect(unpackPoolLocator('N1')).toEqual({
+      poolId: 'N1',
     });
   });
 

--- a/src/tokens/tokens.util.spec.ts
+++ b/src/tokens/tokens.util.spec.ts
@@ -55,7 +55,7 @@ describe('Util', () => {
   it('unpackTokenId', () => {
     expect(unpackTokenId('340282366920938463463374607431768211456')).toEqual({
       isFungible: true,
-      poolId: 'F1',
+      poolLocator: 'F1',
     });
     expect(
       unpackTokenId(
@@ -63,7 +63,7 @@ describe('Util', () => {
       ),
     ).toEqual({
       isFungible: false,
-      poolId: 'N1',
+      poolLocator: 'N1',
       tokenIndex: '1',
     });
   });
@@ -83,13 +83,13 @@ describe('Util', () => {
     expect(unpackSubscriptionName('token', 'token:0x123:F1:create')).toEqual({
       prefix: 'token',
       instancePath: '0x123',
-      poolId: 'F1',
+      poolLocator: 'F1',
       event: 'create',
     });
     expect(unpackSubscriptionName('tok:en', 'tok:en:0x123:N1:create')).toEqual({
       prefix: 'tok:en',
       instancePath: '0x123',
-      poolId: 'N1',
+      poolLocator: 'N1',
       event: 'create',
     });
     expect(unpackSubscriptionName('token', 'bad:N1:create')).toEqual({});

--- a/src/tokens/tokens.util.ts
+++ b/src/tokens/tokens.util.ts
@@ -46,14 +46,14 @@ export function encodeHexIDForURI(id: string) {
   return encoded;
 }
 
-export function isFungible(poolId: string) {
-  return poolId[0] === 'F';
+export function isFungible(poolLocator: string) {
+  return poolLocator[0] === 'F';
 }
 
-export function packTokenId(poolId: string, tokenIndex = '0') {
+export function packTokenId(poolLocator: string, tokenIndex = '0') {
   return (
-    (BigInt(isFungible(poolId) ? 0 : 1) << BigInt(255)) |
-    (BigInt(poolId.substr(1)) << BigInt(128)) |
+    (BigInt(isFungible(poolLocator) ? 0 : 1) << BigInt(255)) |
+    (BigInt(poolLocator.substring(1)) << BigInt(128)) |
     BigInt(tokenIndex)
   ).toString();
 }
@@ -63,7 +63,7 @@ export function unpackTokenId(id: string) {
   const isFungible = val >> BigInt(255) === BigInt(0);
   return {
     isFungible: isFungible,
-    poolId: (isFungible ? 'F' : 'N') + (BigInt.asUintN(255, val) >> BigInt(128)),
+    poolLocator: (isFungible ? 'F' : 'N') + (BigInt.asUintN(255, val) >> BigInt(128)),
     tokenIndex: isFungible ? undefined : BigInt.asUintN(128, val).toString(),
   };
 }
@@ -75,10 +75,10 @@ export function packStreamName(prefix: string, instancePath: string) {
 export function packSubscriptionName(
   prefix: string,
   instancePath: string,
-  poolId: string,
+  poolLocator: string,
   event: string,
 ) {
-  return [prefix, instancePath, poolId, event].join(':');
+  return [prefix, instancePath, poolLocator, event].join(':');
 }
 
 export function unpackSubscriptionName(prefix: string, data: string) {
@@ -92,7 +92,7 @@ export function unpackSubscriptionName(prefix: string, data: string) {
   return {
     prefix,
     instancePath: parts[0],
-    poolId: parts[1],
+    poolLocator: parts[1],
     event: parts[2],
   };
 }

--- a/src/tokens/tokens.util.ts
+++ b/src/tokens/tokens.util.ts
@@ -52,6 +52,10 @@ export function isFungible(poolId: string) {
   return poolId[0] === 'F';
 }
 
+/**
+ * Given a pool ID (in format 'F1') and optional token index, compute the
+ * token ID according to the split-byte implementation of the underlying contract.
+ */
 export function packTokenId(poolId: string, tokenIndex = '0') {
   return (
     (BigInt(isFungible(poolId) ? 0 : 1) << BigInt(255)) |
@@ -60,6 +64,9 @@ export function packTokenId(poolId: string, tokenIndex = '0') {
   ).toString();
 }
 
+/**
+ * Given a token ID from the underlying contract, split it into its meaningful parts.
+ */
 export function unpackTokenId(id: string) {
   const val = BigInt(id);
   const isFungible = val >> BigInt(255) === BigInt(0);
@@ -70,6 +77,14 @@ export function unpackTokenId(id: string) {
   };
 }
 
+/**
+ * Given a pool ID (in format 'F1') and optional block number, create a packed
+ * string to be used as a pool locator.
+ *
+ * This should only be called once when the pool is first created! You should
+ * never re-pack a locator during event or request processing (always send
+ * back the one provided as input or unpacked from the subscription).
+ */
 export function packPoolLocator(poolId: string, blockNumber?: string) {
   const encoded = new URLSearchParams();
   encoded.set('id', poolId);
@@ -79,6 +94,9 @@ export function packPoolLocator(poolId: string, blockNumber?: string) {
   return encoded.toString();
 }
 
+/**
+ * Unpack a pool locator string into its meaningful parts.
+ */
 export function unpackPoolLocator(data: string): PoolLocator {
   const encoded = new URLSearchParams(data);
   const tokenId = encoded.get('id');

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -587,7 +587,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-mint',
           data: <TokenMintEvent>{
-            subject: '000000000001/000000/000001',
+            id: '000000000001/000000/000001',
             poolLocator: 'id=F1&block=1',
             to: 'A',
             amount: '5',
@@ -683,7 +683,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-mint',
           data: <TokenMintEvent>{
-            subject: '000000000001/000000/000001',
+            id: '000000000001/000000/000001',
             poolLocator: 'F1',
             to: 'A',
             amount: '5',
@@ -778,7 +778,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-burn',
           data: <TokenBurnEvent>{
-            subject: '000000000001/000000/000001',
+            id: '000000000001/000000/000001',
             poolLocator: 'id=N1&block=1',
             tokenIndex: '1',
             from: 'A',
@@ -864,7 +864,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-transfer',
           data: <TokenTransferEvent>{
-            subject: '000000000001/000000/000001',
+            id: '000000000001/000000/000001',
             poolLocator: 'id=N1&block=1',
             tokenIndex: '1',
             from: 'A',
@@ -937,6 +937,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-approval',
           data: <TokenApprovalEvent>{
+            id: '000000000001/000000/000001',
             subject: 'A:B',
             signer: 'A',
             operator: 'B',
@@ -1067,7 +1068,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-transfer',
           data: <TokenTransferEvent>{
-            subject: '000000000001/000000/000001/000000',
+            id: '000000000001/000000/000001/000000',
             poolLocator: 'N1',
             tokenIndex: '1',
             from: 'A',
@@ -1108,7 +1109,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-transfer',
           data: <TokenTransferEvent>{
-            subject: '000000000001/000000/000001/000001',
+            id: '000000000001/000000/000001/000001',
             poolLocator: 'N1',
             tokenIndex: '2',
             from: 'A',

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -228,7 +228,7 @@ describe('AppController (e2e)', () => {
 
   it('Mint fungible token', async () => {
     const request: TokenMint = {
-      poolId: 'F1',
+      poolLocator: 'F1',
       to: '1',
       amount: '2',
       data: 'test',
@@ -258,7 +258,7 @@ describe('AppController (e2e)', () => {
 
   it('Mint non-fungible token', async () => {
     const request: TokenMint = {
-      poolId: 'N1',
+      poolLocator: 'N1',
       to: '1',
       amount: '2',
       signer: IDENTITY,
@@ -286,7 +286,7 @@ describe('AppController (e2e)', () => {
 
   it('Burn token', async () => {
     const request: TokenBurn = {
-      poolId: 'N1',
+      poolLocator: 'N1',
       tokenIndex: '1',
       from: 'A',
       amount: '1',
@@ -317,7 +317,7 @@ describe('AppController (e2e)', () => {
 
   it('Transfer token', async () => {
     const request: TokenTransfer = {
-      poolId: 'F1',
+      poolLocator: 'F1',
       from: '1',
       to: '2',
       amount: '2',
@@ -348,7 +348,7 @@ describe('AppController (e2e)', () => {
 
   it('Token approval', async () => {
     const request: TokenApproval = {
-      poolId: 'F1',
+      poolLocator: 'F1',
       signer: IDENTITY,
       operator: '2',
       approved: true,
@@ -377,7 +377,7 @@ describe('AppController (e2e)', () => {
   it('Query balance', async () => {
     const request: TokenBalanceQuery = {
       account: '1',
-      poolId: 'F1',
+      poolLocator: 'F1',
       tokenIndex: '0',
     };
     const response: EthConnectReturn = {
@@ -436,7 +436,7 @@ describe('AppController (e2e)', () => {
           event: 'token-pool',
           data: <TokenPoolEvent>{
             standard: 'ERC1155',
-            poolId: 'F1',
+            poolLocator: 'F1',
             type: 'fungible',
             signer: 'bob',
             data: '',
@@ -502,7 +502,7 @@ describe('AppController (e2e)', () => {
           event: 'token-pool',
           data: <TokenPoolEvent>{
             standard: 'ERC1155',
-            poolId: 'F1',
+            poolLocator: 'F1',
             type: 'fungible',
             signer: 'bob',
             data: '',
@@ -588,7 +588,7 @@ describe('AppController (e2e)', () => {
           event: 'token-mint',
           data: <TokenMintEvent>{
             subject: '000000000001/000000/000001',
-            poolId: 'F1',
+            poolLocator: 'F1',
             to: 'A',
             amount: '5',
             signer: 'A',
@@ -683,7 +683,7 @@ describe('AppController (e2e)', () => {
           event: 'token-burn',
           data: <TokenBurnEvent>{
             subject: '000000000001/000000/000001',
-            poolId: 'N1',
+            poolLocator: 'N1',
             tokenIndex: '1',
             from: 'A',
             amount: '1',
@@ -769,7 +769,7 @@ describe('AppController (e2e)', () => {
           event: 'token-transfer',
           data: <TokenTransferEvent>{
             subject: '000000000001/000000/000001',
-            poolId: 'N1',
+            poolLocator: 'N1',
             tokenIndex: '1',
             from: 'A',
             to: 'B',
@@ -844,7 +844,7 @@ describe('AppController (e2e)', () => {
             subject: 'A:B',
             signer: 'A',
             operator: 'B',
-            poolId: 'N1',
+            poolLocator: 'N1',
             approved: true,
             data: '',
             blockchain: {
@@ -918,7 +918,7 @@ describe('AppController (e2e)', () => {
       .expectJson(message => {
         // Only the second transfer should have been processed
         expect(message.event).toEqual('token-transfer');
-        expect(message.data.poolId).toEqual('N1');
+        expect(message.data.poolLocator).toEqual('N1');
         expect(message.data.blockchain.info.blockNumber).toEqual('2');
         return true;
       });
@@ -970,7 +970,7 @@ describe('AppController (e2e)', () => {
           event: 'token-transfer',
           data: <TokenTransferEvent>{
             subject: '000000000001/000000/000001/000000',
-            poolId: 'N1',
+            poolLocator: 'N1',
             tokenIndex: '1',
             from: 'A',
             to: 'B',
@@ -1011,7 +1011,7 @@ describe('AppController (e2e)', () => {
           event: 'token-transfer',
           data: <TokenTransferEvent>{
             subject: '000000000001/000000/000001/000001',
-            poolId: 'N1',
+            poolLocator: 'N1',
             tokenIndex: '2',
             from: 'A',
             to: 'B',

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -587,7 +587,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-mint',
           data: <TokenMintEvent>{
-            id: '000000000001/000000/000001',
+            subject: '000000000001/000000/000001',
             poolId: 'F1',
             to: 'A',
             amount: '5',
@@ -682,7 +682,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-burn',
           data: <TokenBurnEvent>{
-            id: '000000000001/000000/000001',
+            subject: '000000000001/000000/000001',
             poolId: 'N1',
             tokenIndex: '1',
             from: 'A',
@@ -768,7 +768,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-transfer',
           data: <TokenTransferEvent>{
-            id: '000000000001/000000/000001',
+            subject: '000000000001/000000/000001',
             poolId: 'N1',
             tokenIndex: '1',
             from: 'A',
@@ -841,7 +841,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-approval',
           data: <TokenApprovalEvent>{
-            id: 'A:B',
+            subject: 'A:B',
             signer: 'A',
             operator: 'B',
             poolId: 'N1',
@@ -969,7 +969,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-transfer',
           data: <TokenTransferEvent>{
-            id: '000000000001/000000/000001/000000',
+            subject: '000000000001/000000/000001/000000',
             poolId: 'N1',
             tokenIndex: '1',
             from: 'A',
@@ -1010,7 +1010,7 @@ describe('AppController (e2e)', () => {
         expect(message).toEqual(<WebSocketMessage>{
           event: 'token-transfer',
           data: <TokenTransferEvent>{
-            id: '000000000001/000000/000001/000001',
+            subject: '000000000001/000000/000001/000001',
             poolId: 'N1',
             tokenIndex: '2',
             from: 'A',

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -436,7 +436,7 @@ describe('AppController (e2e)', () => {
           event: 'token-pool',
           data: <TokenPoolEvent>{
             standard: 'ERC1155',
-            poolLocator: 'F1',
+            poolLocator: 'id=F1&block=1',
             type: 'fungible',
             signer: 'bob',
             data: '',
@@ -502,7 +502,7 @@ describe('AppController (e2e)', () => {
           event: 'token-pool',
           data: <TokenPoolEvent>{
             standard: 'ERC1155',
-            poolLocator: 'F1',
+            poolLocator: 'id=F1&block=1',
             type: 'fungible',
             signer: 'bob',
             data: '',
@@ -536,6 +536,102 @@ describe('AppController (e2e)', () => {
   });
 
   it('Websocket: token mint event', async () => {
+    eventstream.getSubscription.mockReturnValueOnce(<EventStreamSubscription>{
+      name: packSubscriptionName(TOPIC, '0x123', 'id=F1&block=1', ''),
+    });
+
+    http.get = jest.fn(
+      () =>
+        new FakeObservable(<EthConnectReturn>{
+          output: 'firefly://token/{id}',
+        }),
+    );
+
+    await server
+      .ws('/api/ws')
+      .exec(() => {
+        expect(eventHandler).toBeDefined();
+        eventHandler([
+          <TransferSingleEvent>{
+            subId: 'sb-123',
+            signature: transferSingleEventSignature,
+            address: '0x00001',
+            blockNumber: '1',
+            transactionIndex: '0x0',
+            transactionHash: '0x123',
+            logIndex: '1',
+            timestamp: '2020-01-01 00:00:00Z',
+            data: {
+              id: '340282366920938463463374607431768211456',
+              from: ZERO_ADDRESS,
+              to: 'A',
+              operator: 'A',
+              value: '5',
+              transaction: {
+                blockNumber: '1',
+                transactionIndex: '0x0',
+                transactionHash: '0x123',
+                logIndex: '1',
+              },
+            },
+            inputMethod: 'mintFungible',
+            inputArgs: {
+              data: '0x74657374',
+            },
+          },
+        ]);
+      })
+      .expectJson(message => {
+        expect(message.id).toBeDefined();
+        delete message.id;
+        expect(message).toEqual(<WebSocketMessage>{
+          event: 'token-mint',
+          data: <TokenMintEvent>{
+            subject: '000000000001/000000/000001',
+            poolLocator: 'id=F1&block=1',
+            to: 'A',
+            amount: '5',
+            signer: 'A',
+            uri: 'firefly://token/0000000000000000000000000000000100000000000000000000000000000000',
+            data: 'test',
+            blockchain: {
+              id: '000000000001/000000/000001',
+              name: 'TransferSingle',
+              location: 'address=0x00001',
+              signature: transferSingleEventSignature,
+              timestamp: '2020-01-01 00:00:00Z',
+              output: {
+                id: '340282366920938463463374607431768211456',
+                from: ZERO_ADDRESS,
+                to: 'A',
+                operator: 'A',
+                value: '5',
+                transaction: {
+                  blockNumber: '1',
+                  transactionIndex: '0x0',
+                  transactionHash: '0x123',
+                  logIndex: '1',
+                },
+              },
+              info: {
+                address: '0x00001',
+                blockNumber: '1',
+                transactionIndex: '0x0',
+                transactionHash: '0x123',
+                logIndex: '1',
+                signature: transferSingleEventSignature,
+              },
+            },
+          },
+        });
+        return true;
+      });
+
+    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(http.get).toHaveBeenCalledWith(`${BASE_URL}${INSTANCE_PATH}/uri?input=0`, {});
+  });
+
+  it('Websocket: token mint event with old pool ID', async () => {
     eventstream.getSubscription.mockReturnValueOnce(<EventStreamSubscription>{
       name: packSubscriptionName(TOPIC, '0x123', 'F1', ''),
     });
@@ -633,7 +729,7 @@ describe('AppController (e2e)', () => {
 
   it('Websocket: token burn event', async () => {
     eventstream.getSubscription.mockReturnValueOnce(<EventStreamSubscription>{
-      name: packSubscriptionName(TOPIC, '0x123', 'N1', ''),
+      name: packSubscriptionName(TOPIC, '0x123', 'id=N1&block=1', ''),
     });
 
     http.get = jest.fn(
@@ -683,7 +779,7 @@ describe('AppController (e2e)', () => {
           event: 'token-burn',
           data: <TokenBurnEvent>{
             subject: '000000000001/000000/000001',
-            poolLocator: 'N1',
+            poolLocator: 'id=N1&block=1',
             tokenIndex: '1',
             from: 'A',
             amount: '1',
@@ -728,7 +824,7 @@ describe('AppController (e2e)', () => {
 
   it('Websocket: token transfer event', async () => {
     eventstream.getSubscription.mockReturnValueOnce(<EventStreamSubscription>{
-      name: packSubscriptionName(TOPIC, '0x123', 'N1', ''),
+      name: packSubscriptionName(TOPIC, '0x123', 'id=N1&block=1', ''),
     });
 
     http.get = jest.fn(
@@ -769,7 +865,7 @@ describe('AppController (e2e)', () => {
           event: 'token-transfer',
           data: <TokenTransferEvent>{
             subject: '000000000001/000000/000001',
-            poolLocator: 'N1',
+            poolLocator: 'id=N1&block=1',
             tokenIndex: '1',
             from: 'A',
             to: 'B',
@@ -810,7 +906,7 @@ describe('AppController (e2e)', () => {
 
   it('Websocket: token approval event', async () => {
     eventstream.getSubscription.mockReturnValueOnce(<EventStreamSubscription>{
-      name: packSubscriptionName(TOPIC, '0x123', 'N1', ''),
+      name: packSubscriptionName(TOPIC, '0x123', 'id=N1&block=1', ''),
     });
 
     await server
@@ -844,7 +940,7 @@ describe('AppController (e2e)', () => {
             subject: 'A:B',
             signer: 'A',
             operator: 'B',
-            poolLocator: 'N1',
+            poolLocator: 'id=N1&block=1',
             approved: true,
             data: '',
             blockchain: {
@@ -875,7 +971,9 @@ describe('AppController (e2e)', () => {
   });
 
   it('Websocket: token transfer event from wrong pool', () => {
-    const sub = <EventStreamSubscription>{ name: packSubscriptionName(TOPIC, '0x123', 'N1', '') };
+    const sub = <EventStreamSubscription>{
+      name: packSubscriptionName(TOPIC, '0x123', 'id=N1&block=1', ''),
+    };
     eventstream.getSubscription.mockReturnValueOnce(sub).mockReturnValueOnce(sub);
 
     return server
@@ -918,7 +1016,7 @@ describe('AppController (e2e)', () => {
       .expectJson(message => {
         // Only the second transfer should have been processed
         expect(message.event).toEqual('token-transfer');
-        expect(message.data.poolLocator).toEqual('N1');
+        expect(message.data.poolLocator).toEqual('id=N1&block=1');
         expect(message.data.blockchain.info.blockNumber).toEqual('2');
         return true;
       });
@@ -1118,7 +1216,7 @@ describe('AppController (e2e)', () => {
     };
 
     eventstream.getSubscription.mockReturnValueOnce(<EventStreamSubscription>{
-      name: packSubscriptionName(TOPIC, '0x123', 'F1', ''),
+      name: packSubscriptionName(TOPIC, '0x123', 'id=F1&block=1', ''),
     });
 
     await server
@@ -1157,7 +1255,7 @@ describe('AppController (e2e)', () => {
     };
 
     eventstream.getSubscription.mockReturnValueOnce(<EventStreamSubscription>{
-      name: packSubscriptionName(TOPIC, '0x123', 'F1', ''),
+      name: packSubscriptionName(TOPIC, '0x123', 'id=F1&block=1', ''),
     });
 
     const ws1 = server.ws('/api/ws');
@@ -1214,7 +1312,9 @@ describe('AppController (e2e)', () => {
       },
     };
 
-    const sub = <EventStreamSubscription>{ name: packSubscriptionName(TOPIC, '0x123', 'F1', '') };
+    const sub = <EventStreamSubscription>{
+      name: packSubscriptionName(TOPIC, '0x123', 'id=F1&block=1', ''),
+    };
     eventstream.getSubscription.mockReturnValueOnce(sub).mockReturnValueOnce(sub);
 
     const ws1 = server.ws('/api/ws');


### PR DESCRIPTION
Token pools now have a "locator" instead of an "id". This also introduces the concept of packing the originating block number into the pool locator (in a similar packing manner to the erc20erc721 connector), therefore removing the "block locator" field.

The thing that was called "id" on approvals is now "subject", and they also have a new "id" that matches the format of the one on transfers.