### PR TITLE
Connector changes to support custom URI's

### DIFF
--- a/samples/solidity/contracts/ERC1155MixedFungible.sol
+++ b/samples/solidity/contracts/ERC1155MixedFungible.sol
@@ -63,8 +63,8 @@ contract ERC1155MixedFungible is Context, ERC1155, IERC1155MixedFungible {
         _;
     }
 
-    constructor(string memory _uri) ERC1155(_uri) {
-        _baseTokenURI = _uri;
+    constructor(string memory uri) ERC1155(uri) {
+        _baseTokenURI = uri;
     }
 
     function supportsInterface(
@@ -129,7 +129,7 @@ contract ERC1155MixedFungible is Context, ERC1155, IERC1155MixedFungible {
         maxIndex[type_id] = SafeMath.add(to.length, maxIndex[type_id]);
 
         for (uint256 i = 0; i < to.length; ++i) {
-            uint256 id  = type_id | index + 1;
+            uint256 id = type_id | index + i;
             _mint(to[i], id, 1, data);
             _setNonFungibleURI(type_id, id, _uri);
         }

--- a/samples/solidity/contracts/ERC1155MixedFungible.sol
+++ b/samples/solidity/contracts/ERC1155MixedFungible.sol
@@ -183,4 +183,7 @@ contract ERC1155MixedFungible is Context, ERC1155, IERC1155MixedFungible {
         }
     }
 
+    function baseTokenUri() public view virtual override returns (string memory) {
+        return _baseTokenURI;
+    }
 }

--- a/samples/solidity/contracts/IERC1155MixedFungible.sol
+++ b/samples/solidity/contracts/IERC1155MixedFungible.sol
@@ -51,4 +51,5 @@ import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
     uint256 id
   ) external returns (string memory);
 
+  function baseTokenUri() external returns(string memory);
  }

--- a/samples/solidity/test/ERC1155MixedFungible.ts
+++ b/samples/solidity/test/ERC1155MixedFungible.ts
@@ -23,7 +23,7 @@ describe ('ERC1155MixedFungible - Unit Tests', function () {
   it('Verify interface ID', async function () {
     const checkerFactory = await ethers.getContractFactory('InterfaceCheck');
     const checker: InterfaceCheck = await checkerFactory.connect(deployerSignerA).deploy();
-    expect(await checker.erc1155WithUri()).to.equal('0xdbd97cf5');
+    expect(await checker.erc1155WithUri()).to.equal('0xa1d87d57');
   })
 
   it('Deploy - should deploy a new ERC1155 instance with the default uri', async function () {
@@ -69,7 +69,7 @@ describe ('ERC1155MixedFungible - Unit Tests', function () {
       deployedERC1155.connect(deployerSignerA).mintNonFungibleWithURI(typeId, [deployerSignerA.address], "0x00", "testURI")
     ).to.emit(deployedERC1155, "TransferSingle");
 
-    const tokenId = BigInt("57896044618658097711785492504343953926975274699741220483192166611388333031426");
+    const tokenId = BigInt("57896044618658097711785492504343953926975274699741220483192166611388333031425");
 
     expect(await deployedERC1155.uri(tokenId)).to.equal("testURI");   
   });

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -299,6 +299,10 @@ export class TokenPoolEventInfo {
 
   @ApiProperty()
   typeId: string;
+
+  @ApiProperty()
+  @IsOptional()
+  baseUri?: string;
 }
 
 export class TokenPoolEvent extends tokenEventBase {

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -91,6 +91,8 @@ const poolConfigDescription =
   'Optional configuration info for the token pool. Reserved for future use.';
 const approvalConfigDescription =
   'Optional configuration info for the token approval. Reserved for future use.';
+const transferConfigDescription =
+  'Optional configuration info for the token transfer. Reserved for future use.';
 
 export class InitRequest {
   @ApiProperty()
@@ -263,6 +265,10 @@ export class TokenTransfer {
   @ApiProperty()
   @IsOptional()
   data?: string;
+
+  @ApiProperty({ description: transferConfigDescription })
+  @IsOptional()
+  config?: any;
 }
 
 export class TokenMint extends OmitType(TokenTransfer, ['tokenIndex', 'from']) {

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -33,7 +33,7 @@ export interface EthConnectAsyncResponse {
 }
 
 export interface EthConnectReturn {
-  output: string;
+  output: any;
 }
 
 export interface TokenPoolCreationEvent extends Event {
@@ -265,7 +265,11 @@ export class TokenTransfer {
   data?: string;
 }
 
-export class TokenMint extends OmitType(TokenTransfer, ['tokenIndex', 'from']) {}
+export class TokenMint extends OmitType(TokenTransfer, ['tokenIndex', 'from']) {
+  @ApiProperty()
+  @IsOptional()
+  uri?: string;
+}
 export class TokenBurn extends OmitType(TokenTransfer, ['to']) {}
 
 // Websocket notifications

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -71,6 +71,7 @@ import {
 const TOKEN_STANDARD = 'ERC1155';
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const BASE_SUBSCRIPTION_NAME = 'base';
+const CUSTOM_URI_IID = '0xdbd97cf5';
 
 const tokenCreateEvent = 'TokenPoolCreation';
 const tokenCreateEventSignatureOld = 'TokenCreate(address,uint256,bytes)';
@@ -101,6 +102,7 @@ export class TokensService {
   stream: EventStream | undefined;
   username: string;
   password: string;
+  supportsCustomUri: boolean;
 
   constructor(
     private http: HttpService,
@@ -148,6 +150,25 @@ export class TokensService {
         tokenCreateEvent,
       ),
     );
+
+    this.supportsCustomUri = await this.queryUriSupport();
+  }
+
+  async queryUriSupport() {
+    try {
+      const result = await this.query('/supportsInterface', {
+        interfaceId: CUSTOM_URI_IID,
+      });
+      this.logger.debug(
+        `Resullt for URI support on instance '${this.instancePath}': ${result.output}`,
+      );
+      return result.output === true;
+    } catch (err) {
+      this.logger.log(
+        `Failed to query URI support on instance '${this.instancePath}': assuming false`,
+      );
+      return false;
+    }
   }
 
   private async getStream() {
@@ -383,12 +404,22 @@ export class TokensService {
         to.push(dto.to);
       }
 
-      const response = await this.invoke('/mintNonFungible', dto.signer, dto.requestId, {
-        type_id: typeId,
-        to,
-        data: encodeHex(dto.data ?? ''),
-      });
-      return { id: response.id };
+      if (dto.uri !== undefined && this.supportsCustomUri === true) {
+        const response = await this.invoke('/mintNonFungibleWithURI', dto.signer, dto.requestId, {
+          type_id: typeId,
+          to,
+          data: encodeHex(dto.data ?? ''),
+          _uri: dto.uri,
+        });
+        return { id: response.id };
+      } else {
+        const response = await this.invoke('/mintNonFungible', dto.signer, dto.requestId, {
+          type_id: typeId,
+          to,
+          data: encodeHex(dto.data ?? ''),
+        });
+        return { id: response.id };
+      }
     }
   }
 
@@ -687,16 +718,18 @@ class TokenListener implements EventListener {
     };
   }
 
-  private async getTokenUri(id: string) {
-    if (this.uriPattern === undefined) {
-      // Fetch and cache the URI pattern (assume it is the same for all tokens)
-      try {
-        const response = await this.service.query('/uri?input=0');
-        this.uriPattern = response.output;
-      } catch (err) {
-        return '';
+  private async getTokenUri(id: string): Promise<string> {
+    try {
+      const response = await this.service.query('/uri', {
+        id: id,
+      });
+      const output = response.output as string;
+      if (output.includes('{id}') === true) {
+        return output.replace('{id}', encodeHexIDForURI(id));
       }
+      return output;
+    } catch (err) {
+      return '';
     }
-    return this.uriPattern.replace('{id}', encodeHexIDForURI(id));
   }
 }

--- a/test/app.e2e-context.ts
+++ b/test/app.e2e-context.ts
@@ -7,7 +7,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppModule } from '../src/app.module';
-import { EventStreamReply , Event } from '../src/event-stream/event-stream.interfaces';
+import { EventStreamReply, Event } from '../src/event-stream/event-stream.interfaces';
 import { EventStreamService } from '../src/event-stream/event-stream.service';
 import { EventStreamProxyGateway } from '../src/eventstream-proxy/eventstream-proxy.gateway';
 import { TokensService } from '../src/tokens/tokens.service';

--- a/test/suites/websocket.ts
+++ b/test/suites/websocket.ts
@@ -431,7 +431,11 @@ export default (context: TestContext) => {
       });
 
     expect(context.http.get).toHaveBeenCalledTimes(1);
-    expect(context.http.get).toHaveBeenCalledWith(`${BASE_URL}${INSTANCE_PATH}/uri?input=0`, {});
+    expect(context.http.get).toHaveBeenCalledWith(`${BASE_URL}${INSTANCE_PATH}/uri`, {
+      params: {
+        id: '57896044618658097711785492504343953926975274699741220483192166611388333031425',
+      },
+    });
   });
 
   it('Token burn event', async () => {
@@ -528,7 +532,11 @@ export default (context: TestContext) => {
       });
 
     expect(context.http.get).toHaveBeenCalledTimes(1);
-    expect(context.http.get).toHaveBeenCalledWith(`${BASE_URL}${INSTANCE_PATH}/uri?input=0`, {});
+    expect(context.http.get).toHaveBeenCalledWith(`${BASE_URL}${INSTANCE_PATH}/uri`, {
+      params: {
+        id: '57896044618658097711785492504343953926975274699741220483192166611388333031425',
+      },
+    });
   });
 
   it('Token transfer event', async () => {
@@ -612,7 +620,11 @@ export default (context: TestContext) => {
       });
 
     expect(context.http.get).toHaveBeenCalledTimes(1);
-    expect(context.http.get).toHaveBeenCalledWith(`${BASE_URL}${INSTANCE_PATH}/uri?input=0`, {});
+    expect(context.http.get).toHaveBeenCalledWith(`${BASE_URL}${INSTANCE_PATH}/uri`, {
+      params: {
+        id: '57896044618658097711785492504343953926975274699741220483192166611388333031425',
+      },
+    });
   });
 
   it('Token approval event', async () => {
@@ -858,8 +870,12 @@ export default (context: TestContext) => {
         return true;
       });
 
-    expect(context.http.get).toHaveBeenCalledTimes(1);
-    expect(context.http.get).toHaveBeenCalledWith(`${BASE_URL}${INSTANCE_PATH}/uri?input=0`, {});
+    expect(context.http.get).toHaveBeenCalledTimes(2);
+    expect(context.http.get).toHaveBeenCalledWith(`${BASE_URL}${INSTANCE_PATH}/uri`, {
+      params: {
+        id: '57896044618658097711785492504343953926975274699741220483192166611388333031426',
+      },
+    });
   });
 
   it('Success receipt', () => {


### PR DESCRIPTION
* adds `uri` as a parameter to the `/mint` api
* adds `baseUri` to `TokenPoolEventInfo` on contracts that support the custom uri interface