### PR TITLE
Fix readiness check for EVMConenct where CONTRACT_ADDRESS is set

### DIFF
--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -39,8 +39,8 @@ export class HealthController {
     return this.health.check([
       () =>
         this.http.pingCheck(
-          'ethconnect-contract',
-          this.tokensService.instanceUrl,
+          'ethereum-connector',
+          `${this.tokensService.baseUrl}/status`,
           basicAuth(this.tokensService.username, this.tokensService.password),
         ),
     ]);


### PR DESCRIPTION
In this scenario instanceUrl is unused, but we still use it in the readiness check. Hence:

```
[Nest] 19  - 11/13/2022, 5:26:10 AM     LOG [RequestLogging] GET /api/v1/health/readiness
[Nest] 19  - 11/13/2022, 5:26:10 AM   ERROR [HealthCheckService] Health Check has failed! {"ethconnect-contract":{"status":"down","message":"Request failed with status code 404","statusCode":404,"statusText":"Not Found"}}
[Nest] 19  - 11/13/2022, 5:26:10 AM    WARN [RequestLogging] GET /api/v1/health/readiness - 503 Service Unavailable Exception
```

Proposed fix is just to check availability of the downstream connector, which is either EthConnect or EVMConnect - both support the `/status` endpoint.
