### PR TITLE
Encapsulate support queries better inside AbiMapper

### DIFF
--- a/src/tokens/abimapper.service.ts
+++ b/src/tokens/abimapper.service.ts
@@ -55,14 +55,9 @@ export class AbiMapperService {
     return this.getAllMethods(abi, allSignatures);
   }
 
-  getAbi(uriSupport = true) {
-    if (uriSupport === false) {
-      // The newer ERC1155MixedFungible schema is a strict superset of the old, with a
-      // few new methods around URIs. Assume the URI methods exist, unless
-      // uriSupport is explicitly set to false.
-      return ERC1155MixedFungibleOldAbi;
-    }
-    return ERC1155MixedFungibleAbi;
+  async getAbi(address: string) {
+    const uriSupport = await this.supportsInterface(address, CUSTOM_URI_IID);
+    return uriSupport ? ERC1155MixedFungibleAbi : ERC1155MixedFungibleOldAbi;
   }
 
   private signatureMatch(method: IAbiMethod, signature: MethodSignature) {
@@ -137,17 +132,14 @@ export class AbiMapperService {
     try {
       const result = await this.blockchain.query(address, SupportsInterface, [iid]);
       support = result.output === true;
+      this.logger.log(`Querying interface '${iid}' support on contract '${address}': ${support}`);
     } catch (err) {
-      // do nothing
+      this.logger.log(
+        `Querying interface '${iid}' support on contract '${address}': failed (assuming false)`,
+      );
     }
 
     this.supportCache.set(cacheKey, support);
     return support;
-  }
-
-  async supportsMintWithUri(address: string): Promise<boolean> {
-    const result = await this.supportsInterface(address, CUSTOM_URI_IID);
-    this.logger.log(`Querying URI support on contract '${address}': ${result}`);
-    return result;
   }
 }

--- a/test/suites/api.ts
+++ b/test/suites/api.ts
@@ -169,7 +169,6 @@ export default (context: TestContext) => {
 
     await context.server.post('/mint').send(request).expect(202).expect({ id: requestId });
 
-    expect(context.http.post).toHaveBeenCalledTimes(1);
     expect(context.http.post).toHaveBeenCalledWith(
       `${BASE_URL}`,
       {
@@ -202,7 +201,6 @@ export default (context: TestContext) => {
 
     await context.server.post('/mint').send(request).expect(202).expect({ id: '1' });
 
-    expect(context.http.post).toHaveBeenCalledTimes(1);
     expect(context.http.post).toHaveBeenCalledWith(
       `${BASE_URL}`,
       {
@@ -240,7 +238,6 @@ export default (context: TestContext) => {
 
     await context.server.post('/burn').send(request).expect(202).expect({ id: '1' });
 
-    expect(context.http.post).toHaveBeenCalledTimes(1);
     expect(context.http.post).toHaveBeenCalledWith(
       `${BASE_URL}`,
       {
@@ -278,7 +275,6 @@ export default (context: TestContext) => {
 
     await context.server.post('/transfer').send(request).expect(202).expect({ id: '1' });
 
-    expect(context.http.post).toHaveBeenCalledTimes(1);
     expect(context.http.post).toHaveBeenCalledWith(
       `${BASE_URL}`,
       {
@@ -310,7 +306,6 @@ export default (context: TestContext) => {
 
     await context.server.post('/approval').send(request).expect(202).expect({ id: '1' });
 
-    expect(context.http.post).toHaveBeenCalledTimes(1);
     expect(context.http.post).toHaveBeenCalledWith(
       `${BASE_URL}`,
       {


### PR DESCRIPTION
Brings this connector inline with the latest ABI mapper changes in https://github.com/hyperledger/firefly-tokens-erc20-erc721/pull/109.