### PR TITLE
Encode the values passed in "poolData"

### DIFF
--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -374,6 +374,9 @@ export class TokenPoolEvent extends tokenEventBase {
   symbol?: string;
 
   @ApiProperty()
+  poolData?: string;
+
+  @ApiProperty()
   info: TokenPoolEventInfo;
 }
 

--- a/src/tokens/tokens.listener.ts
+++ b/src/tokens/tokens.listener.ts
@@ -145,6 +145,7 @@ export class TokenListener implements EventListener {
       data: <TokenPoolEvent>{
         standard: TOKEN_STANDARD,
         interfaceFormat: InterfaceFormat.ABI,
+        poolData: unpackedSub.poolData,
         poolLocator: packedPoolLocator,
         type: unpackedId.isFungible ? TokenType.FUNGIBLE : TokenType.NONFUNGIBLE,
         signer: output.operator,

--- a/src/tokens/tokens.util.spec.ts
+++ b/src/tokens/tokens.util.spec.ts
@@ -90,6 +90,9 @@ describe('Util', () => {
 
   it('packSubscriptionName', () => {
     expect(packSubscriptionName('0x123', 'F1', 'create', 'ns1')).toEqual('fft:0x123:F1:create:ns1');
+    expect(packSubscriptionName('0x123', 'F1', 'create', 'ns1:test')).toEqual(
+      'fft:0x123:F1:create:ns1%3Atest',
+    );
   });
 
   it('unpackSubscriptionName', () => {
@@ -104,6 +107,12 @@ describe('Util', () => {
       poolLocator: 'F1',
       event: 'create',
       poolData: undefined,
+    });
+    expect(unpackSubscriptionName('fft:0x123:F1:create:ns1%3Atest')).toEqual({
+      instancePath: '0x123',
+      poolLocator: 'F1',
+      event: 'create',
+      poolData: 'ns1:test',
     });
   });
 });

--- a/src/tokens/tokens.util.ts
+++ b/src/tokens/tokens.util.ts
@@ -124,7 +124,13 @@ export function packSubscriptionName(
   poolData?: string,
 ) {
   if (poolData !== undefined) {
-    return [SUBSCRIPTION_PREFIX, instancePath, poolLocator, event, poolData].join(':');
+    return [
+      SUBSCRIPTION_PREFIX,
+      instancePath,
+      poolLocator,
+      event,
+      encodeURIComponent(poolData),
+    ].join(':');
   }
   return [SUBSCRIPTION_PREFIX, instancePath, poolLocator, event].join(':');
 }
@@ -136,7 +142,7 @@ export function unpackSubscriptionName(data: string) {
       instancePath: parts[1],
       poolLocator: parts[2],
       event: parts[3],
-      poolData: parts[4],
+      poolData: decodeURIComponent(parts[4]),
     };
   } else if (parts.length === 4) {
     return {

--- a/test/suites/websocket.ts
+++ b/test/suites/websocket.ts
@@ -87,6 +87,7 @@ export default (context: TestContext) => {
           data: <TokenPoolEvent>{
             standard: 'ERC1155',
             interfaceFormat: 'abi',
+            poolData: 'default',
             poolLocator: 'F1',
             type: 'fungible',
             signer: 'bob',
@@ -122,7 +123,7 @@ export default (context: TestContext) => {
 
   it('Token pool event from base subscription', () => {
     context.eventstream.getSubscription.mockReturnValueOnce(<EventStreamSubscription>{
-      name: packSubscriptionName('0x123', 'base', '', 'default'),
+      name: packSubscriptionName('0x123', 'base', ''),
     });
 
     return context.server
@@ -227,6 +228,7 @@ export default (context: TestContext) => {
           data: <TokenPoolEvent>{
             standard: 'ERC1155',
             interfaceFormat: 'abi',
+            poolData: 'default',
             poolLocator: 'address=0x00001&id=F1&block=1',
             type: 'fungible',
             signer: 'bob',


### PR DESCRIPTION
This ensures that the special character ":" (in particular) will be properly escaped.

Also, send "poolData" back in pool creation/activation events (instead of only in transfers/approvals).