### PR TITLE
Mtls support

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,13 @@ The configurable retry settings are:
 Setting `RETRY_CONDITION` to `""` disables retries. Setting `RETRY_MAX_ATTEMPTS` to `-1` causes it to retry indefinitely.
 
 Note, the token connector will make a total of `RETRY_MAX_ATTEMPTS` + 1 calls for a given retryable call (1 original attempt and `RETRY_MAX_ATTEMPTS` retries)
+
+## TLS
+
+Mutual TLS can be enabled by providing three environment variables:
+
+- `TLS_CA`
+- `TLS_CERT`
+- `TLS_KEY`
+
+Each should be a path to a file on disk. Providing all three environment variables will result in a token connector running with TLS enabled, and requiring all clients to provide client certificates signed by the certificate authority.

--- a/src/event-stream/event-stream.service.ts
+++ b/src/event-stream/event-stream.service.ts
@@ -20,7 +20,7 @@ import { AxiosRequestConfig } from 'axios';
 import { lastValueFrom } from 'rxjs';
 import * as WebSocket from 'ws';
 import { IAbiMethod } from '../tokens/tokens.interfaces';
-import { basicAuth } from '../utils';
+import { getHttpRequestOptions } from '../utils';
 import { Context } from '../request-context/request-context.decorator';
 import { FFRequestIDHeader } from '../request-context/constants';
 import {
@@ -173,7 +173,7 @@ export class EventStreamService {
       }
     }
     headers[FFRequestIDHeader] = ctx.requestId;
-    const config = basicAuth(this.username, this.password);
+    const config = getHttpRequestOptions(this.username, this.password);
     config.headers = headers;
     return config;
   }
@@ -181,7 +181,7 @@ export class EventStreamService {
   async getStreams(): Promise<EventStream[]> {
     const response = await lastValueFrom(
       this.http.get<EventStream[]>(new URL('/eventstreams', this.baseUrl).href, {
-        ...basicAuth(this.username, this.password),
+        ...getHttpRequestOptions(this.username, this.password),
       }),
     );
     return response.data;

--- a/src/event-stream/event-stream.service.ts
+++ b/src/event-stream/event-stream.service.ts
@@ -20,7 +20,7 @@ import { AxiosRequestConfig } from 'axios';
 import { lastValueFrom } from 'rxjs';
 import * as WebSocket from 'ws';
 import { IAbiMethod } from '../tokens/tokens.interfaces';
-import { getHttpRequestOptions } from '../utils';
+import { getHttpRequestOptions, getWebsocketOptions } from '../utils';
 import { Context } from '../request-context/request-context.decorator';
 import { FFRequestIDHeader } from '../request-context/constants';
 import {
@@ -58,9 +58,7 @@ export class EventStreamSocket {
     this.disconnectDetected = false;
     this.closeRequested = false;
 
-    const auth =
-      this.username && this.password ? { auth: `${this.username}:${this.password}` } : undefined;
-    this.ws = new WebSocket(this.url, auth);
+    this.ws = new WebSocket(this.url, getWebsocketOptions(this.username, this.password));
     this.ws
       .on('open', () => {
         if (this.disconnectDetected) {

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -17,7 +17,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { HealthCheckService, HealthCheck, HttpHealthIndicator } from '@nestjs/terminus';
 import { BlockchainConnectorService } from '../tokens/blockchain.service';
-import { basicAuth } from '../utils';
+import { getHttpRequestOptions } from '../utils';
 
 @Controller('health')
 export class HealthController {
@@ -41,7 +41,7 @@ export class HealthController {
         this.http.pingCheck(
           'ethconnect',
           this.blockchain.baseUrl,
-          basicAuth(this.blockchain.username, this.blockchain.password),
+          getHttpRequestOptions(this.blockchain.username, this.blockchain.password),
         ),
     ]);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ShutdownSignal, ValidationPipe } from '@nestjs/common';
+import { NestApplicationOptions, ShutdownSignal, ValidationPipe } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
@@ -35,6 +35,7 @@ import { EventStreamService } from './event-stream/event-stream.service';
 import { BlockchainConnectorService, RetryConfiguration } from './tokens/blockchain.service';
 import { requestIDMiddleware } from './request-context/request-id.middleware';
 import { newContext } from './request-context/request-context.decorator';
+import { getNestOptions } from './utils';
 
 const API_DESCRIPTION = `
 <p>All POST APIs are asynchronous. Listen for websocket notifications on <code>/api/ws</code>.
@@ -49,7 +50,8 @@ export function getApiConfig() {
 }
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, getNestOptions());
+
   app.setGlobalPrefix('api/v1');
   app.useWebSocketAdapter(new WsAdapter(app));
   app.useGlobalPipes(new ValidationPipe({ whitelist: true }));

--- a/src/tokens/blockchain.service.ts
+++ b/src/tokens/blockchain.service.ts
@@ -25,7 +25,7 @@ import {
 } from '@nestjs/common';
 import { lastValueFrom } from 'rxjs';
 import { EventStreamReply } from '../event-stream/event-stream.interfaces';
-import { basicAuth } from '../utils';
+import { getHttpRequestOptions } from '../utils';
 import { Context } from '../request-context/request-context.decorator';
 import { FFRequestIDHeader } from '../request-context/constants';
 import {
@@ -82,7 +82,7 @@ export class BlockchainConnectorService {
       }
     }
     headers[FFRequestIDHeader] = ctx.requestId;
-    const config = basicAuth(this.username, this.password);
+    const config = getHttpRequestOptions(this.username, this.password);
     config.headers = headers;
     return config;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,7 +39,7 @@ export const getHttpRequestOptions = (username: string, password: string) => {
   }
   const certs = getCertificates();
   if (certs) {
-    requestOptions.httpsAgent = new https.Agent(certs);
+    requestOptions.httpsAgent = new https.Agent({ ...certs, requestCert: true });
   }
   return requestOptions;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,35 @@
+import * as fs from 'fs';
+import * as https from 'https';
+import { NestApplicationOptions } from '@nestjs/common';
 import { AxiosRequestConfig } from 'axios';
 
-export const basicAuth = (username: string, password: string) => {
+interface Certificates {
+  key: string;
+  cert: string;
+  ca: string;
+}
+
+const getCertificates = (): Certificates | undefined => {
+  let key, cert, ca;
+  if (
+    process.env['TLS_KEY'] === undefined ||
+    process.env['TLS_CERT'] === undefined ||
+    process.env['TLS_CA'] === undefined
+  ) {
+    return undefined;
+  }
+  try {
+    key = fs.readFileSync(process.env['TLS_KEY']).toString();
+    cert = fs.readFileSync(process.env['TLS_CERT']).toString();
+    ca = fs.readFileSync(process.env['TLS_CA']).toString();
+  } catch (error) {
+    console.error(`Error reading certificates: ${error}`);
+    process.exit(-1);
+  }
+  return { key, cert, ca };
+};
+
+export const getHttpRequestOptions = (username: string, password: string) => {
   const requestOptions: AxiosRequestConfig = {};
   if (username !== '' && password !== '') {
     requestOptions.auth = {
@@ -8,5 +37,18 @@ export const basicAuth = (username: string, password: string) => {
       password: password,
     };
   }
+  const certs = getCertificates();
+  if (certs) {
+    requestOptions.httpsAgent = new https.Agent(certs);
+  }
   return requestOptions;
+};
+
+export const getNestOptions = (): NestApplicationOptions => {
+  const options: NestApplicationOptions = {};
+  const certs = getCertificates();
+  if (certs) {
+    options.httpsOptions = certs;
+  }
+  return options;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as https from 'https';
 import { NestApplicationOptions } from '@nestjs/common';
 import { AxiosRequestConfig } from 'axios';
+import { ClientOptions } from 'ws';
 
 interface Certificates {
   key: string;
@@ -27,6 +28,22 @@ const getCertificates = (): Certificates | undefined => {
     process.exit(-1);
   }
   return { key, cert, ca };
+};
+
+export const getWebsocketOptions = (username: string, password: string): ClientOptions => {
+  const requestOptions: ClientOptions = {};
+  if (username && username !== '' && password && password !== '') {
+    requestOptions.headers = {
+      Authorization: `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`,
+    };
+  }
+  const certs = getCertificates();
+  if (certs) {
+    requestOptions.ca = certs.ca;
+    requestOptions.cert = certs.cert;
+    requestOptions.key = certs.key;
+  }
+  return requestOptions;
 };
 
 export const getHttpRequestOptions = (username: string, password: string) => {


### PR DESCRIPTION
Adds support for configuring the token connector with certificates to use when standing up the nest server. Providing the ceritificates will result in a TLS server that requests client certs on all API calls.