### PR TITLE
Add status suffix to readiness probe

### DIFF
--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -40,7 +40,7 @@ export class HealthController {
       () =>
         this.http.pingCheck(
           'ethconnect',
-          this.blockchain.baseUrl,
+          `${this.blockchain.baseUrl}/status`,
           getHttpRequestOptions(this.blockchain.username, this.blockchain.password),
         ),
     ]);


### PR DESCRIPTION
The readiness probe is configured to hit the root of the EVMConnect API - this will give a 405. It needs the status suffix. The ERC20-ERC721 connector already has this suffix.