### PR TITLE
Extract a clearer IERC1155Factory interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ token IDs (inclusive). Note: Because ERC1155 defines the token ID as uint256, th
 is `0x0` to `0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff`.
 
 If `config.address` is specified, the connector will invoke the `create()` method (as defined in the
-`IERC1155MixedFungible` interface) of the ERC1155 token contract at the specified address.
+[IERC1155Factory](samples/solidity/contracts/IERC1155Factory.sol) interface) of the ERC1155 token
+contract at the specified address.
 
 If `config.address` is not specified, and `CONTRACT_ADDRESS` is set in the connector's
 environment, the `create()` method of that contract will be invoked.

--- a/samples/solidity/contracts/ERC1155MixedFungible.sol
+++ b/samples/solidity/contracts/ERC1155MixedFungible.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
-import "@openzeppelin/contracts/utils/Context.sol";
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
-import "./IERC1155MixedFungible.sol";
+import '@openzeppelin/contracts/token/ERC1155/ERC1155.sol';
+import '@openzeppelin/contracts/utils/Context.sol';
+import '@openzeppelin/contracts/utils/math/SafeMath.sol';
+import './IERC1155MixedFungible.sol';
 
 /**
  * Example ERC1155 with mixed fungible/non-fungible token support.
@@ -36,24 +36,24 @@ contract ERC1155MixedFungible is Context, ERC1155, IERC1155MixedFungible {
     uint256 constant TYPE_MASK = type(uint128).max << 128;
     uint256 constant NF_INDEX_MASK = type(uint128).max;
     uint256 constant TYPE_NF_BIT = 1 << 255;
+    uint256 constant NF_POOL_SIZE = 1 << 128;
 
     uint256 nonce;
-    mapping (uint256 => address) public creators;
-    mapping (uint256 => uint256) public maxIndex;
+    mapping(uint256 => address) public creators;
+    mapping(uint256 => uint256) public maxIndex;
 
     // inherited ERC1155 `_uri` is private, so need our own within this contract
     string private _baseTokenURI;
 
     // mapping from type ID | index => custom token URIs for non-fungible tokens
     // fallback behavior if missing is to use the default base URI
-    mapping (uint256 => string) private _nfTokenURIs;
+    mapping(uint256 => string) private _nfTokenURIs;
 
-    event TokenPoolCreation(address indexed operator, uint256 indexed type_id, bytes data);
-
-    function isFungible(uint256 id) internal pure returns(bool) {
+    function isFungible(uint256 id) internal pure returns (bool) {
         return id & TYPE_NF_BIT == 0;
     }
-    function isNonFungible(uint256 id) internal pure returns(bool) {
+
+    function isNonFungible(uint256 id) internal pure returns (bool) {
         return id & TYPE_NF_BIT == TYPE_NF_BIT;
     }
 
@@ -75,73 +75,85 @@ contract ERC1155MixedFungible is Context, ERC1155, IERC1155MixedFungible {
             super.supportsInterface(interfaceId);
     }
 
-    function create(bool is_fungible, bytes calldata data)
-        external
-        virtual
-        override
-        returns(uint256 type_id)
-    {
-        type_id = (++nonce << 128);
-        if (!is_fungible)
-          type_id = type_id | TYPE_NF_BIT;
+    function create(bool is_fungible, bytes calldata data) external virtual override {
+        uint256 type_id = (++nonce << 128);
+        if (!is_fungible) type_id = type_id | TYPE_NF_BIT;
 
         creators[type_id] = _msgSender();
 
-        emit TokenPoolCreation(_msgSender(), type_id, data);
+        emit TokenPoolCreation(
+            _msgSender(),
+            is_fungible,
+            type_id,
+            is_fungible ? type_id : type_id + NF_POOL_SIZE - 1,
+            data
+        );
     }
 
-    function _setNonFungibleURI(uint256 type_id, uint256 id, string memory _uri)
-        private
-        creatorOnly(type_id)
-    {
-        require(isNonFungible(type_id), "ERC1155MixedFungible: id does not represent a non-fungible type");
+    function _setNonFungibleURI(
+        uint256 type_id,
+        uint256 id,
+        string memory _uri
+    ) private creatorOnly(type_id) {
+        require(
+            isNonFungible(type_id),
+            'ERC1155MixedFungible: id does not represent a non-fungible type'
+        );
         _nfTokenURIs[id] = _uri;
     }
 
-    function mintNonFungible(uint256 type_id, address[] calldata to, bytes calldata data)
-        external
-        virtual
-        override
-        creatorOnly(type_id)
-    {
-        require(isNonFungible(type_id), "ERC1155MixedFungible: id does not represent a non-fungible type");
+    function mintNonFungible(
+        uint256 type_id,
+        address[] calldata to,
+        bytes calldata data
+    ) external virtual override creatorOnly(type_id) {
+        require(
+            isNonFungible(type_id),
+            'ERC1155MixedFungible: id does not represent a non-fungible type'
+        );
 
         // Indexes are 1-based.
         uint256 index = maxIndex[type_id] + 1;
         maxIndex[type_id] = SafeMath.add(to.length, maxIndex[type_id]);
 
         for (uint256 i = 0; i < to.length; ++i) {
-            _mint(to[i], type_id | index + i, 1, data);
+            _mint(to[i], type_id | (index + i), 1, data);
         }
     }
 
-    function mintNonFungibleWithURI(uint256 type_id, address[] calldata to, bytes calldata data, string memory _uri)
-        external
-        virtual
-        override
-        creatorOnly(type_id)
-    {
-        require(isNonFungible(type_id), "ERC1155MixedFungible: id does not represent a non-fungible type");
+    function mintNonFungibleWithURI(
+        uint256 type_id,
+        address[] calldata to,
+        bytes calldata data,
+        string memory _uri
+    ) external virtual override creatorOnly(type_id) {
+        require(
+            isNonFungible(type_id),
+            'ERC1155MixedFungible: id does not represent a non-fungible type'
+        );
 
         // Indexes are 1-based.
         uint256 index = maxIndex[type_id] + 1;
         maxIndex[type_id] = SafeMath.add(to.length, maxIndex[type_id]);
 
         for (uint256 i = 0; i < to.length; ++i) {
-            uint256 id = type_id | index + i;
+            uint256 id = type_id | (index + i);
             _mint(to[i], id, 1, data);
             _setNonFungibleURI(type_id, id, _uri);
         }
     }
 
-    function mintFungible(uint256 type_id, address[] calldata to, uint256[] calldata amounts, bytes calldata data)
-        external
-        virtual
-        override
-        creatorOnly(type_id)
-    {
-        require(isFungible(type_id), "ERC1155MixedFungible: id does not represent a fungible type");
-        require(to.length == amounts.length, "ERC1155MixedFungible: to and amounts length mismatch");
+    function mintFungible(
+        uint256 type_id,
+        address[] calldata to,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) external virtual override creatorOnly(type_id) {
+        require(isFungible(type_id), 'ERC1155MixedFungible: id does not represent a fungible type');
+        require(
+            to.length == amounts.length,
+            'ERC1155MixedFungible: to and amounts length mismatch'
+        );
 
         for (uint256 i = 0; i < to.length; ++i) {
             _mint(to[i], type_id, amounts[i], data);
@@ -150,28 +162,31 @@ contract ERC1155MixedFungible is Context, ERC1155, IERC1155MixedFungible {
 
     // Reference:
     // https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC1155/extensions/ERC1155Burnable.sol
-    function burn(address from, uint256 id, uint256 amount, bytes calldata data)
-        external
-        virtual
-        override
-    {
+    function burn(
+        address from,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) external virtual override {
         require(
             from == _msgSender() || isApprovedForAll(from, _msgSender()),
-            "ERC1155MixedFungible: caller is not owner nor approved"
+            'ERC1155MixedFungible: caller is not owner nor approved'
         );
 
         _burn(from, id, amount);
     }
 
-    function setApprovalForAllWithData(address operator, bool approved, bytes calldata data)
-        external
-        virtual
-        override
-    {
+    function setApprovalForAllWithData(
+        address operator,
+        bool approved,
+        bytes calldata data
+    ) external virtual override {
         setApprovalForAll(operator, approved);
     }
 
-    function uri(uint256 id) public view virtual override(IERC1155MixedFungible, ERC1155) returns (string memory) {
+    function uri(
+        uint256 id
+    ) public view virtual override(IERC1155MixedFungible, ERC1155) returns (string memory) {
         string memory _tokenUri = _nfTokenURIs[id];
         bytes memory tempURITest = bytes(_tokenUri);
 

--- a/samples/solidity/contracts/IERC1155Factory.sol
+++ b/samples/solidity/contracts/IERC1155Factory.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.0;
+
+import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
+
+/**
+ * ERC1155 interface that supports creating partitions of fungible and non-fungible tokens.
+ * The implementation may decide how to allocate these "pools" of value, and should emit the
+ * TokenPoolCreation event to advertise each newly created partition (with start_id and end_id
+ * being the inclusive start and end indexes of the ERC1155 id space).
+ */
+interface IERC1155Factory is IERC165 {
+    event TokenPoolCreation(
+        address indexed operator,
+        bool indexed is_fungible,
+        uint256 start_id,
+        uint256 end_id,
+        bytes data
+    );
+
+    function create(bool is_fungible, bytes calldata data) external;
+}

--- a/samples/solidity/contracts/IERC1155MixedFungible.sol
+++ b/samples/solidity/contracts/IERC1155MixedFungible.sol
@@ -3,53 +3,40 @@
 pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
+import './IERC1155Factory.sol';
 
 /**
  * ERC1155 interface with mint, burn, and attached data support for fungible & non-fungible tokens.
  * Non-fungible tokens also have support for custom URI's.
  */
- interface IERC1155MixedFungible is IERC165 {
-  function create(
-    bool is_fungible,
-    bytes calldata data
-  ) external returns (uint256);
+interface IERC1155MixedFungible is IERC165, IERC1155Factory {
+    function create(bool is_fungible, bytes calldata data) external override;
 
-  function mintNonFungible(
-    uint256 type_id,
-    address[] calldata to,
-    bytes calldata data
-  ) external;
+    function mintNonFungible(uint256 type_id, address[] calldata to, bytes calldata data) external;
 
-  function mintNonFungibleWithURI(
-    uint256 type_id,
-    address[] calldata to,
-    bytes calldata data,
-    string memory _uri
-  ) external;
+    function mintNonFungibleWithURI(
+        uint256 type_id,
+        address[] calldata to,
+        bytes calldata data,
+        string memory _uri
+    ) external;
 
-  function mintFungible(
-    uint256 type_id,
-    address[] calldata to,
-    uint256[] calldata amounts,
-    bytes calldata data
-  ) external;
+    function mintFungible(
+        uint256 type_id,
+        address[] calldata to,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) external;
 
-  function burn(
-    address from,
-    uint256 id,
-    uint256 amount,
-    bytes calldata data
-  ) external;
+    function burn(address from, uint256 id, uint256 amount, bytes calldata data) external;
 
-  function setApprovalForAllWithData(
-    address operator,
-    bool approved,
-    bytes calldata data
-  ) external;
+    function setApprovalForAllWithData(
+        address operator,
+        bool approved,
+        bytes calldata data
+    ) external;
 
-  function uri(
-    uint256 id
-  ) external returns (string memory);
+    function uri(uint256 id) external returns (string memory);
 
-  function baseTokenUri() external returns(string memory);
- }
+    function baseTokenUri() external returns (string memory);
+}

--- a/samples/solidity/test/ERC1155MixedFungible.ts
+++ b/samples/solidity/test/ERC1155MixedFungible.ts
@@ -5,17 +5,17 @@ import { ERC1155MixedFungible, InterfaceCheck } from '../typechain';
 
 describe('ERC1155MixedFungible - Unit Tests', () => {
   const baseUri = 'https://firefly/{id}';
-  const fungibleTokenTypeId = BigInt('340282366920938463463374607431768211456');
+  const fungibleTokenTypeId = BigInt('0x100000000000000000000000000000000');
   const nonFungibleTokenTypeId = BigInt(
-    '57896044618658097711785492504343953926975274699741220483192166611388333031424',
+    '0x8000000000000000000000000000000100000000000000000000000000000000',
   );
   const nonFungibleTokenId = BigInt(
-    '57896044618658097711785492504343953926975274699741220483192166611388333031425',
+    '0x8000000000000000000000000000000100000000000000000000000000000001',
   );
+  const poolSize = BigInt(1) << BigInt(128);
 
   const ONE_ADDRESS = '0x1111111111111111111111111111111111111111';
 
-  let Factory;
   let deployedERC1155: ERC1155MixedFungible;
   let deployerSignerA: SignerWithAddress;
   let signerB: SignerWithAddress;
@@ -24,7 +24,7 @@ describe('ERC1155MixedFungible - Unit Tests', () => {
   beforeEach(async () => {
     [deployerSignerA, signerB, signerC] = await ethers.getSigners();
 
-    Factory = await ethers.getContractFactory('ERC1155MixedFungible');
+    const Factory = await ethers.getContractFactory('ERC1155MixedFungible');
     deployedERC1155 = await Factory.connect(deployerSignerA).deploy(baseUri);
     await deployedERC1155.deployed();
   });
@@ -41,15 +41,26 @@ describe('ERC1155MixedFungible - Unit Tests', () => {
 
   context('Create function', () => {
     it('should support deployment of a new fungible token pool without data', async () => {
-      await expect(deployedERC1155.connect(deployerSignerA).create(true, '0x00')).to.emit(
-        deployedERC1155,
-        'TokenPoolCreation',
-      );
+      await expect(deployedERC1155.connect(deployerSignerA).create(true, '0x00'))
+        .to.emit(deployedERC1155, 'TokenPoolCreation')
+        .withArgs(
+          '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          true,
+          fungibleTokenTypeId,
+          fungibleTokenTypeId,
+          '0x00',
+        );
     });
     it('should support deployment of a new non-fungible token pool without data', async () => {
       await expect(deployedERC1155.connect(deployerSignerA).create(false, '0x00'))
         .to.emit(deployedERC1155, 'TokenPoolCreation')
-        .withArgs('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', nonFungibleTokenTypeId, '0x00');
+        .withArgs(
+          '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          false,
+          nonFungibleTokenTypeId,
+          nonFungibleTokenTypeId + poolSize - BigInt(1),
+          '0x00',
+        );
     });
   });
 
@@ -58,7 +69,13 @@ describe('ERC1155MixedFungible - Unit Tests', () => {
       beforeEach(async () => {
         await expect(deployedERC1155.connect(deployerSignerA).create(false, '0x00'))
           .to.emit(deployedERC1155, 'TokenPoolCreation')
-          .withArgs('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', nonFungibleTokenTypeId, '0x00');
+          .withArgs(
+            '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            false,
+            nonFungibleTokenTypeId,
+            nonFungibleTokenTypeId + poolSize - BigInt(1),
+            '0x00',
+          );
       });
       it('signer should be able to mint their own tokens', async () => {
         await expect(
@@ -86,7 +103,13 @@ describe('ERC1155MixedFungible - Unit Tests', () => {
       beforeEach(async () => {
         await expect(deployedERC1155.connect(deployerSignerA).create(true, '0x00'))
           .to.emit(deployedERC1155, 'TokenPoolCreation')
-          .withArgs('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', fungibleTokenTypeId, '0x00');
+          .withArgs(
+            '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            true,
+            fungibleTokenTypeId,
+            fungibleTokenTypeId,
+            '0x00',
+          );
       });
       it('signer should be able to mint their own tokens', async () => {
         await expect(
@@ -132,7 +155,13 @@ describe('ERC1155MixedFungible - Unit Tests', () => {
       beforeEach(async () => {
         await expect(deployedERC1155.connect(deployerSignerA).create(false, '0x00'))
           .to.emit(deployedERC1155, 'TokenPoolCreation')
-          .withArgs('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', nonFungibleTokenTypeId, '0x00');
+          .withArgs(
+            '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            false,
+            nonFungibleTokenTypeId,
+            nonFungibleTokenTypeId + poolSize - BigInt(1),
+            '0x00',
+          );
         await expect(
           deployedERC1155
             .connect(deployerSignerA)
@@ -246,7 +275,13 @@ describe('ERC1155MixedFungible - Unit Tests', () => {
       beforeEach(async () => {
         await expect(deployedERC1155.connect(deployerSignerA).create(true, '0x00'))
           .to.emit(deployedERC1155, 'TokenPoolCreation')
-          .withArgs('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', fungibleTokenTypeId, '0x00');
+          .withArgs(
+            '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            true,
+            fungibleTokenTypeId,
+            fungibleTokenTypeId,
+            '0x00',
+          );
         await expect(
           deployedERC1155
             .connect(deployerSignerA)
@@ -372,7 +407,13 @@ describe('ERC1155MixedFungible - Unit Tests', () => {
       beforeEach(async () => {
         await expect(deployedERC1155.connect(deployerSignerA).create(false, '0x00'))
           .to.emit(deployedERC1155, 'TokenPoolCreation')
-          .withArgs('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', nonFungibleTokenTypeId, '0x00');
+          .withArgs(
+            '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            false,
+            nonFungibleTokenTypeId,
+            nonFungibleTokenTypeId + poolSize - BigInt(1),
+            '0x00',
+          );
       });
       it('signer should be able to burn their own tokens', async () => {
         await expect(
@@ -427,7 +468,13 @@ describe('ERC1155MixedFungible - Unit Tests', () => {
       beforeEach(async () => {
         await expect(deployedERC1155.connect(deployerSignerA).create(true, '0x00'))
           .to.emit(deployedERC1155, 'TokenPoolCreation')
-          .withArgs('0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', fungibleTokenTypeId, '0x00');
+          .withArgs(
+            '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            true,
+            fungibleTokenTypeId,
+            fungibleTokenTypeId,
+            '0x00',
+          );
       });
       it('signer should be able to burn their own tokens', async () => {
         await expect(

--- a/src/tokens/tokens.interfaces.ts
+++ b/src/tokens/tokens.interfaces.ts
@@ -47,12 +47,22 @@ export interface ContractInfoResponse {
   address: string;
 }
 
+interface TokenPoolCreationDataV1 {
+  operator: string;
+  type_id: string;
+  data: string;
+}
+
+interface TokenPoolCreationDataV2 {
+  operator: string;
+  is_fungible: boolean;
+  start_id: string;
+  end_id: string;
+  data: string;
+}
+
 export interface TokenPoolCreationEvent extends Event {
-  data: {
-    operator: string;
-    type_id: string;
-    data: string;
-  };
+  data: TokenPoolCreationDataV1 | TokenPoolCreationDataV2;
 }
 
 export interface ApprovalForAllEvent extends Event {


### PR DESCRIPTION
Split the concept of a "pool factory" (which encompasses a single method and a single event) away from all of the other opinionated spellings in the IERC1155MixedFungible interface.

The parameters of the TokenPoolCreation event have also been altered, but both the old and new parameters will be parsed by the listener.