### PR TITLE
Always pass numbers as base 10 to blockchain connector

### DIFF
--- a/src/tokens/tokens.util.spec.ts
+++ b/src/tokens/tokens.util.spec.ts
@@ -54,7 +54,7 @@ describe('Util', () => {
       startId: '0x100000000000000000000000000000000',
       endId: '0x1ffffffffffffffffffffffffffffffff',
     };
-    expect(computeTokenId(pool, '1')).toEqual('0x100000000000000000000000000000001');
+    expect(computeTokenId(pool, '1')).toEqual('340282366920938463463374607431768211457');
   });
 
   it('unpackTokenId', () => {

--- a/src/tokens/tokens.util.ts
+++ b/src/tokens/tokens.util.ts
@@ -54,7 +54,7 @@ export function encodeHexIDForURI(id: string) {
  * Given a pool locator and optional token index, compute the full token ID.
  */
 export function computeTokenId(pool: PoolLocator, tokenIndex = '0') {
-  return '0x' + (BigInt(pool.startId) | BigInt(tokenIndex)).toString(16);
+  return (BigInt(pool.startId) | BigInt(tokenIndex)).toString(10);
 }
 
 /**

--- a/test/suites/api.ts
+++ b/test/suites/api.ts
@@ -223,7 +223,7 @@ export default (context: TestContext) => {
         from: IDENTITY,
         to: CONTRACT_ADDRESS,
         method: ERC1155MixedFungibleAbi.find(m => m.name === 'mintFungible'),
-        params: ['0x100000000000000000000000000000000', ['1'], ['2'], '0x74657374'],
+        params: ['340282366920938463463374607431768211456', ['1'], ['2'], '0x74657374'],
       },
       OPTIONS,
     );
@@ -255,7 +255,7 @@ export default (context: TestContext) => {
         to: CONTRACT_ADDRESS,
         method: ERC1155MixedFungibleAbi.find(m => m.name === 'mintNonFungible'),
         params: [
-          '0x8000000000000000000000000000000100000000000000000000000000000000',
+          '57896044618658097711785492504343953926975274699741220483192166611388333031424',
           ['1', '1'],
           '0x00',
         ],
@@ -293,7 +293,7 @@ export default (context: TestContext) => {
         method: ERC1155MixedFungibleAbi.find(m => m.name === 'burn'),
         params: [
           'A',
-          '0x8000000000000000000000000000000100000000000000000000000000000001',
+          '57896044618658097711785492504343953926975274699741220483192166611388333031425',
           '1',
           '0x747831',
         ],
@@ -328,7 +328,7 @@ export default (context: TestContext) => {
         from: IDENTITY,
         to: CONTRACT_ADDRESS,
         method: ERC1155MixedFungibleAbi.find(m => m.name === 'safeTransferFrom'),
-        params: ['1', '2', '0x100000000000000000000000000000000', '2', '0x00'],
+        params: ['1', '2', '340282366920938463463374607431768211456', '2', '0x00'],
       },
       OPTIONS,
     );
@@ -394,7 +394,7 @@ export default (context: TestContext) => {
         },
         to: CONTRACT_ADDRESS,
         method: ERC1155MixedFungibleAbi.find(m => m.name === 'balanceOf'),
-        params: ['1', '0x100000000000000000000000000000000'],
+        params: ['1', '340282366920938463463374607431768211456'],
       },
       OPTIONS,
     );


### PR DESCRIPTION
While evmconnect supports base 10 or base 16 inputs, ethconnect only supports numbers in base 10.