### PR TITLE
Update to latest OpenZeppelin base contracts

### DIFF
--- a/samples/solidity/contracts/ERC1155MixedFungible.sol
+++ b/samples/solidity/contracts/ERC1155MixedFungible.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import '@openzeppelin/contracts/token/ERC1155/ERC1155.sol';
 import '@openzeppelin/contracts/utils/Context.sol';
-import '@openzeppelin/contracts/utils/math/SafeMath.sol';
 import './IERC1155MixedFungible.sol';
 
 /**
@@ -114,7 +113,7 @@ contract ERC1155MixedFungible is Context, ERC1155, IERC1155MixedFungible {
 
         // Indexes are 1-based.
         uint256 index = maxIndex[type_id] + 1;
-        maxIndex[type_id] = SafeMath.add(to.length, maxIndex[type_id]);
+        maxIndex[type_id] = to.length + maxIndex[type_id];
 
         for (uint256 i = 0; i < to.length; ++i) {
             _mint(to[i], type_id | (index + i), 1, data);
@@ -134,7 +133,7 @@ contract ERC1155MixedFungible is Context, ERC1155, IERC1155MixedFungible {
 
         // Indexes are 1-based.
         uint256 index = maxIndex[type_id] + 1;
-        maxIndex[type_id] = SafeMath.add(to.length, maxIndex[type_id]);
+        maxIndex[type_id] = to.length + maxIndex[type_id];
 
         for (uint256 i = 0; i < to.length; ++i) {
             uint256 id = type_id | (index + i);

--- a/samples/solidity/contracts/IERC1155MixedFungible.sol
+++ b/samples/solidity/contracts/IERC1155MixedFungible.sol
@@ -2,6 +2,7 @@
 
 pragma solidity ^0.8.0;
 
+import '@openzeppelin/contracts/token/ERC1155/extensions/IERC1155MetadataURI.sol';
 import '@openzeppelin/contracts/utils/introspection/IERC165.sol';
 import './IERC1155Factory.sol';
 
@@ -9,7 +10,7 @@ import './IERC1155Factory.sol';
  * ERC1155 interface with mint, burn, and attached data support for fungible & non-fungible tokens.
  * Non-fungible tokens also have support for custom URI's.
  */
-interface IERC1155MixedFungible is IERC165, IERC1155Factory {
+interface IERC1155MixedFungible is IERC165, IERC1155Factory, IERC1155MetadataURI {
     function create(bool is_fungible, bytes calldata data) external override;
 
     function mintNonFungible(uint256 type_id, address[] calldata to, bytes calldata data) external;
@@ -36,7 +37,7 @@ interface IERC1155MixedFungible is IERC165, IERC1155Factory {
         bytes calldata data
     ) external;
 
-    function uri(uint256 id) external returns (string memory);
+    function uri(uint256 id) external view returns (string memory);
 
     function baseTokenUri() external returns (string memory);
 }

--- a/samples/solidity/package-lock.json
+++ b/samples/solidity/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "@hyperledger/firefly-tokens-erc1155-contracts",
 			"version": "0.0.2",
 			"dependencies": {
-				"@openzeppelin/contracts": "^4.5.0"
+				"@openzeppelin/contracts": "^5.0.2"
 			},
 			"devDependencies": {
 				"@nomicfoundation/hardhat-toolbox": "^4.0.0",
@@ -1493,9 +1493,9 @@
 			}
 		},
 		"node_modules/@openzeppelin/contracts": {
-			"version": "4.9.5",
-			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.5.tgz",
-			"integrity": "sha512-ZK+W5mVhRppff9BE6YdR8CC52C8zAvsVAiWhEtQ5+oNxFE6h1WdeWo+FJSF8KKvtxxVYZ7MTP/5KoVpAU3aSWg=="
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.0.2.tgz",
+			"integrity": "sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA=="
 		},
 		"node_modules/@scure/base": {
 			"version": "1.1.5",

--- a/samples/solidity/package.json
+++ b/samples/solidity/package.json
@@ -6,7 +6,7 @@
 		"test": "hardhat test --network hardhat"
 	},
 	"dependencies": {
-		"@openzeppelin/contracts": "^4.5.0"
+		"@openzeppelin/contracts": "^5.0.2"
 	},
 	"devDependencies": {
 		"@nomicfoundation/hardhat-toolbox": "^4.0.0",

--- a/samples/solidity/test/ERC1155MixedFungible.ts
+++ b/samples/solidity/test/ERC1155MixedFungible.ts
@@ -241,7 +241,7 @@ describe('ERC1155MixedFungible - Unit Tests', () => {
               1,
               '0x00',
             ),
-        ).to.be.revertedWith('ERC1155: caller is not token owner or approved');
+        ).to.be.revertedWithCustomError(deployedERC1155, 'ERC1155MissingApprovalForAll');
         expect(
           await deployedERC1155
             .connect(deployerSignerA)
@@ -371,7 +371,7 @@ describe('ERC1155MixedFungible - Unit Tests', () => {
               1,
               '0x00',
             ),
-        ).to.be.revertedWith('ERC1155: caller is not token owner or approved');
+        ).to.be.revertedWithCustomError(deployedERC1155, 'ERC1155MissingApprovalForAll');
         expect(
           await deployedERC1155
             .connect(deployerSignerA)


### PR DESCRIPTION
There is no change to the external function signatures, but this brings us more inline with the latest ERC1155 examples from OpenZeppelin.

The sample now extends ERC1155URIStorage for token URI functionality. There is one slight change in behavior: if you specify a "base URI", then individual token URIs are always understood to be a suffix for that base URI. The previous contract would ignore the base URI when a token URI was specified.

Old contracts will be unchanged, and no functionality in the connector or FireFly will be changed by this new behavior - but users of the contract will need to plan accordingly for how they specify base URI and token URIs.