### PR TITLE
Fixing failing Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM node:20-alpine3.17 as solidity-build
-RUN apk add python3=3.10.13-r0 alpine-sdk=1.0-r1
+FROM node:20-alpine3.19 as solidity-build
+RUN apk add python3=3.11.8-r0 alpine-sdk=1.0-r1
 USER node
 WORKDIR /home/node
 ADD --chown=node:node ./samples/solidity/package*.json ./
@@ -22,7 +22,7 @@ RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/
 RUN trivy fs --format spdx-json --output /sbom.spdx.json /SBOM
 RUN trivy sbom /sbom.spdx.json --severity UNKNOWN,HIGH,CRITICAL --exit-code 1
 
-FROM node:20-alpine3.17
+FROM node:20-alpine3.19
 RUN apk add curl=8.5.0-r0
 # We also need to keep copying it to the old location to maintain compatibility with the FireFly CLI
 COPY --from=solidity-build --chown=1001:0 /home/node/artifacts/contracts/ERC1155MixedFungible.sol/ERC1155MixedFungible.json /root/contracts/


### PR DESCRIPTION
Updating python's pinned version to latest available in alpine repos + updating alpine to latest stable.

As part of these updates the failing build is also fixed: https://github.com/hyperledger/firefly-tokens-erc1155/actions/runs/8472344216