### PR TITLE
Update CODEOWNERS and MAINTAINERS.md 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # FireFly Core Maintainers
-* @awrichar @peterbroadhurst @nguyer @shorsher
+@hyperledger/firefly-tokens-erc1155-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,6 @@ The following is the list of current maintainers this repo:
 | Andrew Richardson | awrichar        | andrew.richardson@kaleido.io | Andrew.Richardson |
 | Peter Broadhurst  | peterbroadhurst | peter.broadhurst@kaleido.io  | peterbroadhurst   |
 | Enrique Lacal     | enriquel8       | enrique.lacal@kaleido.io     | enrique.lacal     |
-
+| Alex Shorsher     | shorsher        | alex.shorsher@kaleido.io     | shorsher          |
 
 For the full list of maintainers across all repos, the expectations of a maintainer and the process for becoming a maintainer, please see the [FireFly Maintainers page on the Hyperledger Wiki](https://wiki.hyperledger.org/display/FIR/Maintainers).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,44 +9,4 @@ The following is the list of current maintainers this repo:
 | Enrique Lacal     | enriquel8       | enrique.lacal@kaleido.io     | enrique.lacal     |
 
 
-This list is to be kept up to date as maintainers are added or removed.
-
-# Expectations of Maintainers
-
-Maintainers are expected to regularly:
-
-- Make contributions to FireFly code repositories including code or documentation
-- Review pull requests
-- Investigate open GitHub issues
-- Participate in Community Calls
-
-# Becoming a Maintainer
-
-The FireFly Project welcomes and encourages people to become maintainers of the project if they are interested and meet the following criteria:
-
-## Criteria for becoming a member
-
-- Expressed interest and commitment to meet the expectations of a maintainer for at least 6 months
-- A consistent track record of contributions to FireFly code repositories which could be:
-  - Enhancements
-  - Bug fixes
-  - Tests
-  - Documentation
-- A consistent track record of helpful code reviews on FireFly code repositories
-- Regular participation in Community Calls
-- A demonstrated interest and aptitude in thought leadership within the FireFly Project
-- Sponsorship from an existing maintainer
-
-There is no specific quantity of contributions or pull requests, or a specific time period over which the candidate must prove their track record. This will be left up to the discretion of the existing maintainers.
-
-## Process for becoming a maintainer
-
-Once the above criteria have been met, the sponsoring maintainer shall propose the addition of the new maintainer at a public Community Call. Existing maintainers shall vote at the next public Community Call whether the new maintainer should be added or not. Proxy votes may be submitted via email _before_ the meeting. A simple majority of the existing maintainers is required for the vote to pass.
-
-## Maintainer resignation
-
-While maintainers are expected in good faith to be committed to the project for a significant period of time, they are under no binding obligation to do so. Maintainers may resign at any time for any reason. If a maintainer wishes to resign they shall open a pull request to update the maintainers list removing themselves from the list.
-
-## Maintainer inactivity
-
-If a maintainer has remained inactive (not meeting the expectations of a maintainer) for a period of time (at least several months), an email should be sent to that maintainer noting their inactivity and asking if they still wish to be a maintainer. If they continue to be inactive after being notified via email, an existing maintainer may propose to remove the inactive maintainer at a public Community Call. Existing maintainers shall vote at the next public Community Call whether the inactive maintainer should be removed or not. Proxy votes may be submitted via email _before_ the meeting. A simple majority of the existing maintainers is required for the vote to pass.
+For the full list of maintainers across all repos, the expectations of a maintainer and the process for becoming a maintainer, please see the [FireFly Maintainers page on the Hyperledger Wiki](https://wiki.hyperledger.org/display/FIR/Maintainers).


### PR DESCRIPTION
Update the CODEOWNERS to match the hyperledger governance repo and the MAINTAINERS.md file

Current list https://github.com/hyperledger/governance/blob/d32a393f45c32cdb6b39ab7ba336b6e8b4f5c8c8/access-control.yaml#L906