### PR TITLE
bump to node22

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -28,8 +28,8 @@ jobs:
             --label commit=$GITHUB_SHA \
             --label build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
             --label tag=${{ steps.build_tag_generator.outputs.BUILD_TAG }} \
-            --build-arg BASE_IMAGE=node:20-alpine3.19 \
-            --build-arg BUILD_IMAGE=node:20-alpine3.19 \
+            --build-arg BASE_IMAGE=node:22-alpine3.19 \
+            --build-arg BUILD_IMAGE=node:22-alpine3.19 \
             --tag ghcr.io/hyperledger/firefly-tokens-erc1155:${{ steps.build_tag_generator.outputs.BUILD_TAG }} .
 
       - name: Tag release

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -21,8 +21,8 @@ jobs:
             --label commit=$GITHUB_SHA \
             --label build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
             --label tag=${GITHUB_REF##*/} \
-            --build-arg BASE_IMAGE=node:20-alpine3.19 \
-            --build-arg BUILD_IMAGE=node:20-alpine3.19 \
+            --build-arg BASE_IMAGE=node:22-alpine3.19 \
+            --build-arg BUILD_IMAGE=node:22-alpine3.19 \
             --tag ghcr.io/hyperledger/firefly-tokens-erc1155:${GITHUB_REF##*/} \
             --tag ghcr.io/hyperledger/firefly-tokens-erc1155:head \
             .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.9.0'
+          node-version: '22.15.0'
       - run: npm ci
       - run: npm run test
 
@@ -30,7 +30,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20.9.0'
+          node-version: '22.15.0'
       - run: npm ci
       - run: npm run compile
       - run: npm run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE
 ARG BUILD_IMAGE
 
 FROM ${BUILD_IMAGE} AS solidity-build
-RUN apk add python3=3.11.11-r0 alpine-sdk=1.0-r1
+RUN apk add python3~3.11 alpine-sdk=1.0-r1
 USER node
 WORKDIR /home/node
 ADD --chown=node:node ./samples/solidity/package*.json ./


### PR DESCRIPTION
Node 18 is now end of life https://nodejs.org/en/about/previous-releases#release-schedule, upgrading to Node 22 LTS