### PR TITLE
chore: update CODEOWNERS for hyperledger-firefly org migration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# FireFly Core Maintainers
-* @hyperledger/firefly-tokens-erc1155-maintainers
+* @hyperledger-firefly/firefly-tokens-erc1155-maintainers


### PR DESCRIPTION
Updates the CODEOWNERS file to reference the `hyperledger-firefly` GitHub organisation instead of `hyperledger` following repo migration.