### PR TITLE
chore: update repo path for hyperledger-firefly org migration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -5,7 +5,7 @@
 repository:
   name: firefly-tokens-erc1155
   description: ERC1155 token integration
-  homepage: https://github.com/hyperledger/firefly-tokens-erc1155
+  homepage: https://github.com/hyperledger-firefly/tokens-erc1155
   default_branch: main
   has_downloads: true
   has_issues: true

--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set build tag
         id: build_tag_generator
         run: |
-          RELEASE_TAG=$(curl https://api.github.com/repos/hyperledger/firefly-tokens-erc1155/releases/latest -s | jq .tag_name -r)
+          RELEASE_TAG=$(curl https://api.github.com/repos/hyperledger-firefly/tokens-erc1155/releases/latest -s | jq .tag_name -r)
           BUILD_TAG=$RELEASE_TAG-$(date +"%Y%m%d")-$GITHUB_RUN_NUMBER
           echo ::set-output name=BUILD_TAG::$BUILD_TAG
 
@@ -30,20 +30,20 @@ jobs:
             --label tag=${{ steps.build_tag_generator.outputs.BUILD_TAG }} \
             --build-arg BASE_IMAGE=node:22-alpine3.19 \
             --build-arg BUILD_IMAGE=node:22-alpine3.19 \
-            --tag ghcr.io/hyperledger/firefly-tokens-erc1155:${{ steps.build_tag_generator.outputs.BUILD_TAG }} .
+            --tag ghcr.io/hyperledger-firefly/tokens-erc1155:${{ steps.build_tag_generator.outputs.BUILD_TAG }} .
 
       - name: Tag release
         if: github.event.pull_request.merged == true
-        run: docker tag ghcr.io/hyperledger/firefly-tokens-erc1155:${{ steps.build_tag_generator.outputs.BUILD_TAG }} ghcr.io/hyperledger/firefly-tokens-erc1155:head
+        run: docker tag ghcr.io/hyperledger-firefly/tokens-erc1155:${{ steps.build_tag_generator.outputs.BUILD_TAG }} ghcr.io/hyperledger-firefly/tokens-erc1155:head
 
       - name: Push docker image
         if: github.event.pull_request.merged == true
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly-tokens-erc1155:${{ steps.build_tag_generator.outputs.BUILD_TAG }}
+          docker push ghcr.io/hyperledger-firefly/tokens-erc1155:${{ steps.build_tag_generator.outputs.BUILD_TAG }}
 
       - name: Push head tag
         if: github.event.pull_request.merged == true
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly-tokens-erc1155:head
+          docker push ghcr.io/hyperledger-firefly/tokens-erc1155:head

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -23,26 +23,26 @@ jobs:
             --label tag=${GITHUB_REF##*/} \
             --build-arg BASE_IMAGE=node:22-alpine3.19 \
             --build-arg BUILD_IMAGE=node:22-alpine3.19 \
-            --tag ghcr.io/hyperledger/firefly-tokens-erc1155:${GITHUB_REF##*/} \
-            --tag ghcr.io/hyperledger/firefly-tokens-erc1155:head \
+            --tag ghcr.io/hyperledger-firefly/tokens-erc1155:${GITHUB_REF##*/} \
+            --tag ghcr.io/hyperledger-firefly/tokens-erc1155:head \
             .
 
       - name: Tag release
         if: github.event.action == 'released'
-        run: docker tag ghcr.io/hyperledger/firefly-tokens-erc1155:${GITHUB_REF##*/} ghcr.io/hyperledger/firefly-tokens-erc1155:latest
+        run: docker tag ghcr.io/hyperledger-firefly/tokens-erc1155:${GITHUB_REF##*/} ghcr.io/hyperledger-firefly/tokens-erc1155:latest
 
       - name: Push docker image
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly-tokens-erc1155:${GITHUB_REF##*/}
+          docker push ghcr.io/hyperledger-firefly/tokens-erc1155:${GITHUB_REF##*/}
 
       - name: Push head tag
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly-tokens-erc1155:head
+          docker push ghcr.io/hyperledger-firefly/tokens-erc1155:head
 
       - name: Push latest tag
         if: github.event.action == 'released'
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/hyperledger/firefly-tokens-erc1155:latest
+          docker push ghcr.io/hyperledger-firefly/tokens-erc1155:latest

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
-    "docker": "docker build --build-arg BASE_IMAGE=node:20-alpine3.19 --build-arg BUILD_IMAGE=node:20-alpine3.19 --tag hyperledger/firefly-tokens-erc1155 .",
+    "docker": "docker build --build-arg BASE_IMAGE=node:20-alpine3.19 --build-arg BUILD_IMAGE=node:20-alpine3.19 --tag hyperledger-firefly/tokens-erc1155 .",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",


### PR DESCRIPTION
Point this repo's self-references and published image namespace at the new location github.com/hyperledger-firefly/tokens-erc1155 (org changed and the 'firefly-' prefix dropped from the repo name):